### PR TITLE
revert(vercel): drop output:'standalone' + --turbopack — both regress Vercel builds

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -1,7 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: true,
-  output: 'standalone',
+  // No `output: 'standalone'` here on purpose — it's for self-hosted/Docker
+  // deploys. Vercel does its own server bundling via the Build Output API
+  // and ignores .next/standalone, but you still pay the file-tracing cost.
   experimental: {
     typedRoutes: false,
   },

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
-  "buildCommand": "next build --turbopack",
+  "buildCommand": "next build",
   "installCommand": "npm ci --no-audit --no-fund",
   "outputDirectory": ".next"
 }

--- a/architecture.md
+++ b/architecture.md
@@ -185,17 +185,20 @@ The CI python job's "try prebaked image" step pulls the `lock-<hash>` tag, so a 
 
 **First run requires GHCR write permission** in the repo settings (Settings → Actions → General → Workflow permissions → "Read and write permissions").
 
-### Vercel (`apps/web/vercel.json` + `next.config.mjs`)
+### Vercel (`apps/web/vercel.json`)
 
 ```json
-{ "buildCommand": "next build --turbopack", "installCommand": "npm ci --no-audit --no-fund" }
+{ "buildCommand": "next build", "installCommand": "npm ci --no-audit --no-fund" }
 ```
 
-```js
-const nextConfig = { output: 'standalone', reactStrictMode: true };
-```
+`npm ci` is deterministic and marginally faster than `npm install` — that's the only change worth making for Vercel. Vercel already caches `.next/cache` automatically.
 
-`output: 'standalone'` reduces deploy size; Turbopack (`next build --turbopack`) is GA in Next 15.5+ and ~30% faster than webpack. Vercel already caches `.next/cache` automatically — realistic ceiling here is ~2×. If a deploy preview breaks under Turbopack, drop the `--turbopack` flag and keep the rest.
+**Two settings to *not* enable for Vercel** (we tried, they regress):
+
+- `output: 'standalone'` is for self-hosted/Docker deploys. Vercel uses its own Build Output API and ignores `.next/standalone`, but you still pay the file-tracing + node_modules-copy cost during build. Measured: ~50% slower Vercel builds.
+- `next build --turbopack` is fine for `next dev` (HMR) but on Vercel the platform's build cache is tuned for the webpack output shape — switching to Turbopack invalidates large parts of that incremental cache, making warm builds more cold-like.
+
+Both are appropriate if/when the web app is ever containerized and run outside Vercel.
 
 ### Railway (`infra/railway/*.json`)
 


### PR DESCRIPTION
## Why

Two settings landed in #10 (commit 89b6f30) under the assumption that what helps self-hosted Docker also helps Vercel. They don't — measured ~50% slower Vercel builds after the merge.

## What's reverted

- **`next.config.mjs`**: drop `output: 'standalone'`. It's for self-hosted Docker. Vercel uses its own Build Output API and ignores `.next/standalone`, but the build still pays the file-tracing pass + node_modules copy.
- **`vercel.json`**: drop `--turbopack`. Turbopack is great for `next dev` but on Vercel the platform's incremental build cache is tuned for webpack's output shape; switching to Turbopack invalidates large parts of that cache.

## What's kept

- `npm ci --no-audit --no-fund` — deterministic, marginally faster, no downside.

## Docs

`architecture.md` updated with an explicit "do not enable on Vercel" note for both settings so this isn't reintroduced accidentally. They remain appropriate if the web app is ever containerized and run outside Vercel.

## Test plan

- [ ] CI green
- [ ] Vercel preview build time returns to (or beats) the pre-#10 baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)