### PR TITLE
fix(railway): scope backtest-api uv cache mount to its Railway service ID

### DIFF
--- a/services/backtest-api/Dockerfile
+++ b/services/backtest-api/Dockerfile
@@ -13,7 +13,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 WORKDIR /app
 COPY --link pyproject.toml uv.lock README.md ./
 
-RUN --mount=type=cache,target=/root/.cache/uv \
+RUN --mount=type=cache,id=s/b705abc8-afbc-4bcd-98df-0b18b859de51-/root/.cache/uv,target=/root/.cache/uv \
     uv sync --frozen --no-dev --no-install-project
 
 FROM python:3.11-slim AS runtime


### PR DESCRIPTION
## Why

Railway's backtest-api deploy was failing on the BuildKit cache mount step. Railway's diagnostic identified the cause: cache mounts need a per-service \`id=\` to avoid cross-service collisions. The generic mount we added in 89b6f30 used the default id (= target path), which clashes with other services using the same cache target.

## The fix

Updates the one line in \`services/backtest-api/Dockerfile\`:

\`\`\`diff
- RUN --mount=type=cache,target=/root/.cache/uv \\
+ RUN --mount=type=cache,id=s/b705abc8-afbc-4bcd-98df-0b18b859de51-/root/.cache/uv,target=/root/.cache/uv \\
\`\`\`

The id format \`s/<railway-service-uuid>-<target-path>\` was provided by Railway's diagnostic.

## Follow-up needed

\`services/strategy-engine/Dockerfile\` and \`services/market-data-stream/Dockerfile\` still use the generic mount. They will likely fail the same way on their next Railway rebuild. Need their Railway service UUIDs to apply the same fix — or remove the cache mount from them entirely as a fallback (loses the cross-build cache, deploys still work just slower-cold).

## Test plan

- [ ] CI green (Python paths only — frontend job skips per paths-filter)
- [ ] Railway backtest-api redeploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)