### PR TITLE
chore(claude): project skills + permission allowlist for Claude Code

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,2 @@
+# Personal permission overrides — never commit.
+settings.local.json

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(railway list *)",
+      "Bash(railway status *)",
+      "Bash(railway logs *)"
+    ]
+  }
+}

--- a/.claude/skills/safe-merge/SKILL.md
+++ b/.claude/skills/safe-merge/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: safe-merge
+description: Safely merge a GitHub PR after verifying CI is green. Runs `gh pr checks <pr>`, only merges if every check passes (or non-required checks are explicitly skipped), then `gh pr merge <pr> --merge --delete-branch`, syncs local main, deletes the local branch. Pass the PR number as the argument. Refuses to use `--auto` (queues unattended merges) or `--squash` unless the user explicitly asks for that strategy.
+---
+
+# safe-merge
+
+You are landing PR `$ARGUMENTS` to main using the verified-CI-then-merge pattern this project uses. Refuse to run if `$ARGUMENTS` is empty or not a number.
+
+## Steps
+
+1. **Fetch latest CI status.** Run `gh pr checks $ARGUMENTS`. Parse the output:
+   - "pass" / "skipping" → fine
+   - "fail" / "ERROR" → STOP and report the failing check(s) with the link from the output. Do not merge.
+   - "pending" / "in_progress" / "queued" → wait. Use `gh pr checks $ARGUMENTS --watch --interval 15` (Bash timeout 300000) to block until terminal. Then re-evaluate.
+
+2. **Confirm mergeability.** Run `gh pr view $ARGUMENTS --json mergeable,mergeStateStatus,baseRefName,headRefName,isDraft`. If `isDraft` is true, STOP — do not flip drafts to ready without explicit user authorization. If `mergeable` is not `MERGEABLE`, STOP and report why.
+
+3. **Merge.** Run `gh pr merge $ARGUMENTS --merge --delete-branch`. Use `--merge` (preserves commit history) by default. Only use `--squash` if the user has stated that preference for this PR. Never use `--auto` from this skill — that queues an unattended merge, which the project's reviewer chain blocks.
+
+4. **Sync local.** Run these as a single Bash chain:
+   ```
+   git fetch origin --prune --quiet && \
+   git checkout main && \
+   git pull --ff-only origin main && \
+   git branch -D <head-branch-name> 2>&1 | tail -1
+   ```
+   The head branch name comes from step 2's output. The `git branch -D` may error if the branch was already cleaned up — that's fine, swallow it.
+
+5. **Report.** One line. Format: `Merged #N as <main-sha-short>. <head branch> deleted locally and remotely.`
+
+## When NOT to use this skill
+
+- PR is in draft → don't unflip; tell the user the PR is draft and stop.
+- CI is failing → don't merge; report the failure.
+- User wants `--squash` or `--rebase` strategy → check the user has actually said so for this specific PR; if not, ask.
+- User wants `--auto` (merge-on-green-eventually) → ask first, since the auto-mode classifier blocks it.
+- The PR base is not `main` → flag it; this skill is meant for landing to main only.
+
+## Anti-patterns to avoid
+
+- Don't add `--admin` to bypass branch protection. If checks fail, fix the cause.
+- Don't `git push --force` to fix a stuck merge. If the PR can't merge, ask.
+- Don't delete remote branches the PR's `--delete-branch` flag would have handled — let `gh` do it.

--- a/.claude/skills/verify-vercel/SKILL.md
+++ b/.claude/skills/verify-vercel/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: verify-vercel
+description: Query the last N Vercel deploys for alpha-kite-max and report build times in a sortable table. Use when the user asks to verify a Vercel build-time change, compare deploy speeds across commits, or check whether a recent change regressed Vercel performance. Optionally takes a baseline target (e.g. "verify against 38s baseline").
+---
+
+# verify-vercel
+
+You are running a Vercel build-time verification for the alpha-kite-max project.
+
+## Project IDs (do not look up — these are stable)
+
+- projectId: `prj_nfufcN3XCf7ZMhPhcEEPT0StFAa5`
+- teamId: `team_3wz9UVlAlA9u7ZmvEFEAIhad`
+
+## Steps
+
+1. **Load the Vercel MCP tools you need.** Call `ToolSearch` with `query: "select:mcp__claude_ai_Vercel__list_deployments,mcp__claude_ai_Vercel__get_deployment"` and `max_results: 3`. Wait for the tools to load.
+
+2. **List recent deployments.** Call `mcp__claude_ai_Vercel__list_deployments` with the project + team IDs. Take the 6 most-recent deployments unless the user asked for a different N.
+
+3. **Fetch full details for each.** For every deployment in the list, call `mcp__claude_ai_Vercel__get_deployment` with the deployment ID and team ID. Capture `createdAt`, `buildingAt`, `ready`, `readyState`, source commit SHA (under `meta.githubCommitSha` typically), and the deployment URL hostname prefix.
+
+4. **Compute build duration.** `build_seconds = (ready - buildingAt) / 1000`. If `buildingAt` is missing or `ready == buildingAt`, mark the deployment as "in flight" — do not invent a number.
+
+5. **Render a table** sorted oldest → newest with columns: Time (UTC HH:MM:SS), Short ID (first 7 chars), Commit (first 7 chars), Build (s, 1 decimal), State.
+
+6. **Report the verdict.** If the user gave a baseline (e.g. "38s baseline") or named a commit to compare against, compute the delta vs baseline for each post-baseline deploy and state plainly whether the trend is at/under/above baseline. If no baseline was given, just report the average of the last 3 READY deploys.
+
+## Style
+
+Keep the response under 250 words total. Lead with the verdict in bold, follow with the table, end with one or two sentences of context. Don't speculate about why a build was slow unless the user asks — just report the numbers.
+
+## When NOT to use this skill
+
+- The user wants to *trigger* a deploy → use `vercel deploy` instead, or ask the user how they want it triggered.
+- The user wants logs from a specific failed deploy → use `mcp__claude_ai_Vercel__get_deployment_build_logs` directly, not this skill.
+- The user is asking about *Railway* deploys → Railway uses the CLI (`railway status`, `railway logs`), not this skill.


### PR DESCRIPTION
## Summary

Adds team-shared Claude Code project config so future sessions started from inside this repo pick up the workflows we landed on today.

## What's added

- **`.claude/settings.json`** — read-only Bash allowlist for `railway list/status/logs`. These are the three commands the `fewer-permission-prompts` skill flagged as not already auto-allowed. The gh/git/vercel/uv equivalents are either built-in read-only or classified as mutating (intentionally not allowlisted at the shared level).

- **`.claude/skills/verify-vercel/SKILL.md`** — query the last N Vercel deploys for this project, render a build-time table, optionally compare to a baseline. Bakes in the alpha-kite-max projectId/teamId.

- **`.claude/skills/safe-merge/SKILL.md`** — the verify-CI-then-merge pattern used for PRs #11/#12/#13 today. Refuses `--auto` + `--admin`, refuses to flip drafts to ready without explicit auth, syncs local main and deletes the local branch.

- **`.claude/.gitignore`** — keeps personal `settings.local.json` overrides (gh pr merge / vercel deploy / uv sync allows) out of the repo.

## Note on activation

Claude Code project settings only load when the session CWD is at or under this repo root. Run from `alpha-kite-max/`, not from the parent directory.

## Test plan

- [ ] CI green
- [ ] In a future Claude Code session started from this repo: \`/verify-vercel\` and \`/safe-merge <pr>\` appear in the slash menu and run as documented
- [ ] \`railway status\` runs without a permission prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)