### PR TITLE
feat(web): nav theme toggle (Auto / Light / Dark)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -11,8 +11,18 @@
   --row-alt: #fafafa;
 }
 
+:root[data-theme="dark"] {
+  --bg: #0a0a0a;
+  --fg: #f5f5f5;
+  --muted: #9ca3af;
+  --border: #1f2937;
+  --accent: #f5f5f5;
+  --row-alt: #111315;
+}
+
 @media (prefers-color-scheme: dark) {
-  :root {
+  :root[data-theme="auto"],
+  :root:not([data-theme]) {
     --bg: #0a0a0a;
     --fg: #f5f5f5;
     --muted: #9ca3af;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -7,9 +7,17 @@ export const metadata: Metadata = {
   description: "Read-only operator dashboard for alpha-kite-v2",
 };
 
+// Runs before React hydrates so the saved theme is applied before first paint —
+// without it, light/dark would flash on reload for users who picked a non-auto
+// preference.
+const themeInitScript = `(function(){try{var t=localStorage.getItem('theme');if(t!=='light'&&t!=='dark'&&t!=='auto')t='auto';document.documentElement.dataset.theme=t;}catch(e){document.documentElement.dataset.theme='auto';}})();`;
+
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
+      </head>
       <body>{children}</body>
     </html>
   );

--- a/apps/web/src/components/Nav.tsx
+++ b/apps/web/src/components/Nav.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { classNames } from "@/lib/format";
+import { ThemeToggle } from "@/components/ThemeToggle";
 
 interface NavProps {
   current: string;
@@ -71,6 +72,7 @@ export function Nav({ current }: NavProps) {
               </Link>
             );
           })}
+          <ThemeToggle />
         </nav>
       </div>
     </header>

--- a/apps/web/src/components/ThemeToggle.tsx
+++ b/apps/web/src/components/ThemeToggle.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
+
+type Theme = "auto" | "light" | "dark";
+
+const ORDER: ReadonlyArray<Theme> = ["auto", "light", "dark"];
+const STORAGE_KEY = "theme";
+
+const LABELS: Record<Theme, string> = {
+  auto: "Auto",
+  light: "Light",
+  dark: "Dark",
+};
+
+const ICONS: Record<Theme, ReactNode> = {
+  auto: (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="2" y="3" width="20" height="14" rx="2" />
+      <line x1="8" y1="21" x2="16" y2="21" />
+      <line x1="12" y1="17" x2="12" y2="21" />
+    </svg>
+  ),
+  light: (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+    </svg>
+  ),
+  dark: (
+    <svg
+      width="14"
+      height="14"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3a7 7 0 0 0 9.79 9.79z" />
+    </svg>
+  ),
+};
+
+function isTheme(value: string | undefined): value is Theme {
+  return value === "auto" || value === "light" || value === "dark";
+}
+
+function nextTheme(current: Theme): Theme {
+  const i = ORDER.indexOf(current);
+  return ORDER[(i + 1) % ORDER.length];
+}
+
+export function ThemeToggle() {
+  const [theme, setTheme] = useState<Theme>("auto");
+
+  useEffect(() => {
+    const current = document.documentElement.dataset.theme;
+    if (isTheme(current)) setTheme(current);
+  }, []);
+
+  function cycle() {
+    const next = nextTheme(theme);
+    setTheme(next);
+    document.documentElement.dataset.theme = next;
+    try {
+      localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      // localStorage may be unavailable (private mode); the in-DOM attribute
+      // still flips the theme for the rest of this page load.
+    }
+  }
+
+  const label = LABELS[theme];
+
+  return (
+    <button
+      type="button"
+      onClick={cycle}
+      aria-label={`Theme: ${label} (click to cycle)`}
+      title={`Theme: ${label} — click to cycle auto / light / dark`}
+      className="flex items-center gap-1.5 rounded border border-[var(--border)] px-2 py-1 text-xs text-[var(--muted)] transition-colors hover:text-[var(--fg)]"
+    >
+      {ICONS[theme]}
+      <span>{label}</span>
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

- Top-right nav cycle button (Auto → Light → Dark) with sun / moon / monitor SVG icons; persists choice to `localStorage`.
- Inline `<head>` script applies the saved theme to `document.documentElement.dataset.theme` before React hydrates, so reloads don't flash light → dark.
- `globals.css` now uses `:root[data-theme="dark"]` for explicit dark; the `prefers-color-scheme: dark` media query only applies when `data-theme` is `"auto"` or unset, so Auto still tracks the OS.

## Test plan

- [ ] Load `/status`, confirm a button labeled **Auto** appears at the right end of the nav.
- [ ] Click cycles **Auto → Light → Dark → Auto**; page colors flip immediately on each click.
- [ ] In **Auto**, toggle the OS dark-mode setting — the page follows. In **Light** or **Dark**, the OS setting is ignored.
- [ ] Reload the page after picking Light or Dark — no flash, the chosen theme is applied before first paint.
- [ ] `npx tsc --noEmit` and `npx next lint` stay clean (already verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)