### PR TITLE
fix(/live-enable): implement the BACKTEST_PASS gate

### DIFF
--- a/apps/web/src/app/backtest/RunBacktestAction.ts
+++ b/apps/web/src/app/backtest/RunBacktestAction.ts
@@ -101,6 +101,17 @@ export async function runBacktest(
       return { ok: false, error: `sidecar ${res.status}: ${text}` };
     }
     const data = (await res.json()) as BacktestResult;
+
+    // Auto-write a BACKTEST_PASS audit row when the run produced closed
+    // trades with positive expectancy. /live-enable's "backtest passed in
+    // last 24h" gate queries audit_log for this event_type.
+    if (data.summary.trades > 0 && data.summary.expectancy_pct > 0) {
+      await writeBacktestPassAudit(input, data).catch(() => {
+        // Audit write is best-effort — never fail the user's backtest run
+        // because the dashboard couldn't write a row.
+      });
+    }
+
     return { ok: true, data };
   } catch (err) {
     return {
@@ -108,6 +119,44 @@ export async function runBacktest(
       error: err instanceof Error ? err.message : String(err),
     };
   }
+}
+
+async function writeBacktestPassAudit(
+  input: BacktestInput,
+  result: BacktestResult,
+): Promise<void> {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  // Without service-role we can't bypass RLS to insert into audit_log.
+  // Skip silently — the rest of the dashboard still works; the gate just
+  // won't auto-flip on backtest success.
+  if (!url || !serviceKey) return;
+  const { createClient } = await import("@supabase/supabase-js");
+  const sb = createClient(url, serviceKey, { auth: { persistSession: false } });
+  const sourceLabel =
+    input.source === "fixture"
+      ? { fixture: input.fixture }
+      : {
+          symbol: input.symbol,
+          start: input.start,
+          end: input.end,
+          interval_seconds: input.intervalSeconds,
+        };
+  await sb.from("audit_log").insert({
+    actor: "dashboard:/backtest",
+    event_type: "BACKTEST_PASS",
+    severity: "INFO",
+    message: `backtest passed: ${result.summary.trades} trades, expectancy ${result.summary.expectancy_pct}%`,
+    payload: {
+      ...sourceLabel,
+      trades: result.summary.trades,
+      wins: result.summary.wins,
+      losses: result.summary.losses,
+      win_rate_pct: result.summary.win_rate_pct,
+      expectancy_pct: result.summary.expectancy_pct,
+      total_pnl_pct: result.summary.total_pnl_pct,
+    },
+  });
 }
 
 export async function listFixtures(): Promise<string[]> {

--- a/apps/web/src/app/live-enable/page.tsx
+++ b/apps/web/src/app/live-enable/page.tsx
@@ -2,6 +2,7 @@ import { Nav } from "@/components/Nav";
 import {
   fetchBrokerSnapshot,
   fetchKillSwitchState,
+  fetchRecentBacktestPass,
   fetchTodayRealizedUsd,
 } from "@/lib/queries";
 import PromoteForm from "./PromoteForm";
@@ -12,10 +13,11 @@ export const revalidate = 0;
 const DEFAULT_DAILY_LOSS_LIMIT_USD = 50;
 
 export default async function LiveEnablePage() {
-  const [brokerSnap, killSwitch, todayRealized] = await Promise.all([
+  const [brokerSnap, killSwitch, todayRealized, backtestPass] = await Promise.all([
     fetchBrokerSnapshot(),
     fetchKillSwitchState(),
     fetchTodayRealizedUsd(),
+    fetchRecentBacktestPass(24),
   ]);
 
   const lossOk = todayRealized > -DEFAULT_DAILY_LOSS_LIMIT_USD;
@@ -46,11 +48,13 @@ export default async function LiveEnablePage() {
     },
     {
       label: "Backtest passed (BACKTEST_PASS audit row in last 24h)",
-      // TODO: write the BACKTEST_PASS audit row from the /backtest UI on
-      //       success, then check it here. For now the gate is informational.
-      ok: false,
-      detail:
-        "Hook this up by writing a BACKTEST_PASS audit row from /backtest after a successful run with positive expectancy.",
+      ok: backtestPass.passed,
+      detail: backtestPass.passed
+        ? `last pass: ${new Date(backtestPass.lastSeen as string).toISOString().slice(0, 19).replace("T", " ")}Z` +
+          (typeof backtestPass.payload?.["expectancy_pct"] === "number"
+            ? ` · expectancy ${(backtestPass.payload["expectancy_pct"] as number).toFixed(2)}%`
+            : "")
+        : "Run a backtest with positive expectancy on /backtest in the last 24h to satisfy this gate.",
     },
   ];
 

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -764,6 +764,30 @@ export async function fetchKillSwitchState(): Promise<{
   return { lastSeen: row.ts, active };
 }
 
+/** Most recent ``BACKTEST_PASS`` audit row, used by /live-enable's
+ *  "backtest passed in last 24h" gate. The Server Action behind the
+ *  /backtest page writes one of these whenever a run finishes with
+ *  positive expectancy. */
+export async function fetchRecentBacktestPass(
+  withinHours = 24,
+): Promise<{ lastSeen: string | null; passed: boolean; payload: Record<string, unknown> | null }> {
+  const supabase = getSupabase();
+  if (!supabase) return { lastSeen: null, passed: false, payload: null };
+  const cutoff = new Date(Date.now() - withinHours * 3_600_000).toISOString();
+  const { data, error } = await supabase
+    .from("audit_log")
+    .select("ts,payload")
+    .eq("event_type", "BACKTEST_PASS")
+    .gte("ts", cutoff)
+    .order("ts", { ascending: false })
+    .limit(1);
+  if (error || !data || data.length === 0) {
+    return { lastSeen: null, passed: false, payload: null };
+  }
+  const row = data[0] as { ts: string; payload: Record<string, unknown> | null };
+  return { lastSeen: row.ts, passed: true, payload: row.payload };
+}
+
 /** Most recent N bars across all symbols. Powers /status's "Live feed"
  *  panel: the initial server-render fills the ring buffer that the
  *  realtime subscription then keeps current. */


### PR DESCRIPTION
## Summary

The `/live-enable` page had two failing gates. This PR fixes the one that was a code stub. Gate 1 (IBKR gateway connected) is a runtime/ops issue documented at the bottom — not a code change.

### Gate 4 — Backtest passed (in last 24h)

Before this PR the gate was hardcoded `ok: false` with a TODO comment. Nothing in the codebase ever wrote a `BACKTEST_PASS` audit row.

This PR wires it end-to-end:

- **`apps/web/src/lib/queries.ts`** — new `fetchRecentBacktestPass(withinHours = 24)` helper.
- **`apps/web/src/app/live-enable/page.tsx`** — replaces the stub; surfaces last-pass timestamp + expectancy in the row's detail.
- **`apps/web/src/app/backtest/RunBacktestAction.ts`** — after a successful run with `summary.trades > 0` AND `summary.expectancy_pct > 0`, the Server Action inserts a `BACKTEST_PASS` row via `SUPABASE_SERVICE_ROLE_KEY`. Best-effort — audit write failures never fail the user's backtest.

### Operator workflow

1. Open `/backtest`, run any backtest that produces closed trades with positive expectancy.
2. Refresh `/live-enable` — the gate flips green and stays green for 24 h.

### Gate 1 — IBKR gateway connected (not in this PR)

Failing on the user's screenshot with detail `no recent BROKER_HEARTBEAT in audit_log`. The strategy-engine *should* be writing one of these every heartbeat (DryRunBroker emits a fake one with `connected=True` even in dry-run mode). Three plausible causes, none of them code:

1. `strategy-engine` Railway service isn't running. Check: `railway logs --service strategy-engine | tail -20` — should see `engine alive` lines.
2. Engine is running but can't write to Supabase. Check audit_log for any rows in the last 5 min: `SELECT MAX(ts), event_type FROM audit_log GROUP BY event_type ORDER BY 1 DESC;`
3. Engine *did* write rows but they're older than the dashboard's freshness window — `fetchBrokerSnapshot()` in `lib/queries.ts` should clarify the threshold.

If diagnostics show (2) or (3), follow-up PR can adjust the freshness window or surface the underlying error in the gate's detail.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean
- [ ] Manual: run a positive-expectancy backtest on `/backtest`, refresh `/live-enable`, confirm gate 4 flips to green with `last pass: …` detail
- [ ] Manual: confirm `audit_log` now contains a `BACKTEST_PASS` row after the run

https://claude.ai/code/session_01T9xB5bMA2937np7Z8Tr3vj

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9xB5bMA2937np7Z8Tr3vj)_