### PR TITLE
fix(ibkr): auto-take-over existing IBKR sessions in headless gateway

### DIFF
--- a/infra/ibkr/ibc-config.ini.template
+++ b/infra/ibkr/ibc-config.ini.template
@@ -23,6 +23,14 @@ DismissNSEComplianceNotice=yes
 DismissPasswordExpiryWarning=yes
 ReadOnlyApi=no
 
+# When IBKR detects another login under the same user (TWS Desktop, web client,
+# another IBC instance, etc.), IB pops a modal asking which session wins. With
+# the default value `manual`, IBC blocks waiting for a human click and the API
+# port never opens. `primary` tells IBC to take over the new session and force
+# the other one to disconnect — the right choice for a headless paper-trading
+# container. Allowed values: primary | primaryoverride | secondary | manual.
+ExistingSessionDetectedAction=primary
+
 # ── Daily session reset ────────────────────────────────────────────────────
 # IBKR forces a daily restart at 23:50 ET. IBC handles the relogin automatically
 # and we additionally rely on the docker healthcheck to bounce the container if


### PR DESCRIPTION
## Summary

The IBKR Gateway sidecar (`infra/ibkr/`) is hung at startup with this dialog:

```
IBC: detected dialog entitled: Existing session detected
IBC: User must choose whether to continue with this session (scenario 1)
```

When IBKR detects another active session under the same user, it pops a modal asking which session should win. IBC's default `ExistingSessionDetectedAction=manual` waits for a human click — but the gateway runs headless on Railway, so the dialog never gets clicked, port 7497 never opens, and `strategy-engine` loops forever on:

```
ERROR ib_insync.client API connection failed: ConnectionRefusedError(111, "Connect call failed ('127.0.0.1', 7497)")
```

That cascades into `/live-enable`'s "IBKR gateway connected" gate being permanently red because `BROKER_HEARTBEAT` audit rows never land.

## Fix

Set `ExistingSessionDetectedAction=primary` in `ibc-config.ini.template`. IBC will take over the new session and force-disconnect the other one. Safe for paper-only since there's no risk of stomping on a real-money client.

## Operator deploy

After merge:

```
railway redeploy --service ibkr-gateway
```

Then ~90 s later:

```
railway logs --service ibkr-gateway | tail -10   # expect "Forking :: API server listening" or similar
railway logs --service strategy-engine | tail -10 # expect "engine alive" / no more connect-refused
```

Refresh `/live-enable` — gate 1 flips green within a heartbeat cycle.

## Test plan

- [ ] Gateway boots without the "Existing session detected" hang
- [ ] strategy-engine `feed connect` succeeds (no more reconnect spam)
- [ ] `audit_log` accumulates `BROKER_HEARTBEAT` rows once per minute
- [ ] `/live-enable` gate 1 turns green

https://claude.ai/code/session_01T9xB5bMA2937np7Z8Tr3vj

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9xB5bMA2937np7Z8Tr3vj)_