### PR TITLE
perf(persistence): batch upserts into 500-row multi-row VALUES

### DIFF
--- a/scripts/backfill_bars.py
+++ b/scripts/backfill_bars.py
@@ -139,10 +139,10 @@ async def run(symbol: str, intervals: list[str], dry_run: bool) -> dict[str, int
         if res.interval not in intervals:
             continue
         bars = _fetch(symbol, res)
-        for bar in bars:
-            await writer.write_bar(bar, feed=f"yfinance_backfill_{res.interval}")
+        if bars:
+            await writer.write_bars(bars, feed=f"yfinance_backfill_{res.interval}")
         counts[res.interval] = len(bars)
-        LOG.info("[%s @ %s] %d bars written", symbol, res.interval, len(bars))
+        LOG.info("[%s @ %s] %d bars persisted", symbol, res.interval, len(bars))
 
     return counts
 

--- a/services/persistence/storage.py
+++ b/services/persistence/storage.py
@@ -189,10 +189,20 @@ class SupabaseBackend:
         rows: list[dict[str, Any]],
         conflict_columns: list[str],
     ) -> None:
+        """Bulk upsert into Postgres in batches of 500 multi-row VALUES.
+
+        Network-bound workloads (e.g. the historical backfill from a laptop
+        to Supabase across the public internet) become brutally slow when
+        each row is its own statement — every INSERT eats one round-trip,
+        so 13k rows * 50ms RTT ~= 11 minutes. Collapsing into multi-row
+        VALUES statements brings that down to ~28 round-trips for the same
+        13k rows. Same on-conflict semantics either way.
+        """
         if not rows:
             return
         pool = await self._ensure_pool()
         cols = list(rows[0].keys())
+        n_cols = len(cols)
         col_sql = ", ".join(f'"{c}"' for c in cols)
         conflict_sql = ", ".join(f'"{c}"' for c in conflict_columns)
         update_cols = [c for c in cols if c not in conflict_columns]
@@ -201,14 +211,30 @@ class SupabaseBackend:
             on_conflict = f"ON CONFLICT ({conflict_sql}) DO UPDATE SET {set_sql}"
         else:
             on_conflict = f"ON CONFLICT ({conflict_sql}) DO NOTHING"
+
+        # 500 rows per statement keeps us comfortably under Postgres's
+        # 65535-parameter cap (with 11 columns per row that's 5500 params).
+        BATCH_SIZE = 500
         async with pool.acquire() as conn:
-            for row in rows:
-                values = [row.get(c) for c in cols]
-                ph = self._placeholders(1, len(cols))
+            for start in range(0, len(rows), BATCH_SIZE):
+                batch = rows[start : start + BATCH_SIZE]
+                value_groups: list[str] = []
+                values_flat: list[Any] = []
+                for j, row in enumerate(batch):
+                    base = j * n_cols
+                    placeholders = ", ".join(
+                        f"${base + k + 1}" for k in range(n_cols)
+                    )
+                    value_groups.append(f"({placeholders})")
+                    for c in cols:
+                        values_flat.append(row.get(c))
                 sql = (
-                    f'INSERT INTO "{table}" ({col_sql}) VALUES ({ph}) {on_conflict}'
+                    f'INSERT INTO "{table}" ({col_sql}) VALUES '
+                    + ", ".join(value_groups)
+                    + " "
+                    + on_conflict
                 )
-                await conn.execute(sql, *values)
+                await conn.execute(sql, *values_flat)
 
     async def select(
         self,

--- a/services/persistence/writer.py
+++ b/services/persistence/writer.py
@@ -58,21 +58,37 @@ class PersistenceWriter:
         await self._backend.insert("ticks", [row])
 
     async def write_bar(self, bar: Bar, feed: str) -> None:
-        row = {
-            "symbol": bar.symbol,
-            "interval_seconds": bar.interval_seconds,
-            "open_time": bar.open_time,
-            "open": _dec_str(bar.open),
-            "high": _dec_str(bar.high),
-            "low": _dec_str(bar.low),
-            "close": _dec_str(bar.close),
-            "volume": bar.volume,
-            "vwap": _dec_str(bar.vwap),
-            "feed": feed,
-        }
+        await self.write_bars([bar], feed)
+
+    async def write_bars(self, bars: list[Bar], feed: str) -> None:
+        """Bulk-write bars in a single batched upsert.
+
+        Use this from any caller that has more than a handful of bars to
+        persist (e.g. ``scripts/backfill_bars.py``). The writer hands every
+        row to ``backend.upsert`` which then collapses them into 500-row
+        multi-row INSERTs — orders of magnitude faster than one upsert per
+        bar over the public internet.
+        """
+        if not bars:
+            return
+        rows = [
+            {
+                "symbol": b.symbol,
+                "interval_seconds": b.interval_seconds,
+                "open_time": b.open_time,
+                "open": _dec_str(b.open),
+                "high": _dec_str(b.high),
+                "low": _dec_str(b.low),
+                "close": _dec_str(b.close),
+                "volume": b.volume,
+                "vwap": _dec_str(b.vwap),
+                "feed": feed,
+            }
+            for b in bars
+        ]
         await self._backend.upsert(
             "bars",
-            [row],
+            rows,
             conflict_columns=["symbol", "interval_seconds", "open_time"],
         )
 


### PR DESCRIPTION
## Summary

The historical-bar backfill running from a laptop to Supabase was network-bound: each `Bar` became its own `INSERT` statement on a single asyncpg connection, so `13k rows × ~50ms RTT` ≈ **11 minutes**. The strategy-engine's per-tick `HEARTBEAT` writes weren't affected (one row at a time, no point batching), but anything that bulk-loads hundreds of rows was paying the round-trip-per-row tax.

## Changes

- **`services/persistence/storage.py`** — `SupabaseBackend.upsert` now chunks `rows` into batches of 500 and emits one multi-row `VALUES` INSERT per batch. Same `ON CONFLICT` semantics. The 500 cap keeps parameter count under Postgres's 65535 limit (5500 params at 11 cols/row for the bars table).
- **`services/persistence/writer.py`** — new `write_bars(list[Bar], feed)` helper that hands the entire list to `backend.upsert` in one call so the batching above actually engages. `write_bar(bar, feed)` becomes a thin wrapper for backward compat.
- **`scripts/backfill_bars.py`** — replaces the per-bar `for` loop with a single `write_bars(bars, ...)` call. The misleading "X bars written" log line becomes "X bars persisted" — future operators won't get fooled by counts that came from yfinance fetches but never reached the database (which is what just happened during the v2 backfill).

## Expected impact

`python -m scripts.backfill_bars --symbol QQQ` end-to-end:

| Resolution | Rows | Before (round-trip-bound) | After (batched) |
|---|---|---|---|
| 1m | ~2,700 | ~2 min | ~0.3 s |
| 5m | ~4,700 | ~4 min | ~0.5 s |
| 1h | ~5,000 | ~4 min | ~0.6 s |
| 1d | ~1,300 | ~1 min | ~0.1 s |
| **Total writes** | **~13,700** | **~11 min** | **~1.5 s** |

yfinance pulls themselves still take ~20 s combined; that's network-bound on the read side and not addressable here.

## Test plan

- [x] `pytest -m "not live and not supabase"` — 170 passed
- [x] `ruff check .` — clean
- [ ] Manual: re-run the backfill end-to-end, confirm sub-30s total elapsed and that all 4 (symbol, interval_seconds) pairs land in the `bars` table

https://claude.ai/code/session_01T9xB5bMA2937np7Z8Tr3vj

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9xB5bMA2937np7Z8Tr3vj)_