### PR TITLE
fix(persistence): asyncpg pool config for Supabase PgBouncer + loud timeouts

### DIFF
--- a/services/persistence/storage.py
+++ b/services/persistence/storage.py
@@ -158,7 +158,27 @@ class SupabaseBackend:
                         schema="pg_catalog",
                     )
 
-            self._pool = await asyncpg.create_pool(self._dsn, init=_init_conn)
+            self._pool = await asyncpg.create_pool(
+                self._dsn,
+                init=_init_conn,
+                # Supabase's pooler (aws-*.pooler.supabase.com) is PgBouncer in
+                # transaction mode. PgBouncer doesn't support the prepared-
+                # statement cache asyncpg builds by default, so we'd hang or
+                # throw "prepared statement S_X already exists" on the second
+                # query. Disabling the cache is the documented fix.
+                statement_cache_size=0,
+                # Bound the pool so we don't exhaust Supabase's connection
+                # quota when many concurrent calls happen (e.g. the parallel
+                # broker_snapshot + audit_log fetches in the dashboard).
+                min_size=1,
+                max_size=4,
+                # Make hangs LOUD. asyncpg's defaults are no-timeout, so a
+                # network blip or pgbouncer cap silently waits forever; the
+                # backfill ran 30+ minutes that way once. 30s per statement
+                # / 10s to acquire a connection is plenty for our workload.
+                command_timeout=30,
+                timeout=10,
+            )
         return self._pool
 
     async def close(self) -> None:


### PR DESCRIPTION
## Summary

Backfill kept hanging mid-run despite PR #18's multi-row VALUES batching. Stack trace showed asyncpg waiting forever inside `pool.acquire()`. Two root causes, one fix each, in a single small change to `SupabaseBackend._ensure_pool`:

1. **Supabase's pooler is PgBouncer in transaction mode.** PgBouncer rejects asyncpg's prepared-statement cache on the second query — manifests as hangs or `prepared statement S_X already exists` errors. Documented fix: `statement_cache_size=0`.
2. **asyncpg's `create_pool` defaults to no timeouts.** A network blip, pgbouncer cap hit, or any transient issue produces an indefinite wait with zero log output. `command_timeout=30` + pool `timeout=10` turn silent hangs into thrown exceptions.

Also bounding the pool (`min_size=1, max_size=4`) so the dashboard's parallel fan-out queries don't exhaust the Supabase connection quota.

## Evidence

Backfill row counts after the silent hang:

```
interval_seconds | rows
-----------------+------
              60 | 2730    ← 1m: full pull (yfinance cap)
             300 | 1696    ← 5m: partial — hung mid-batch here
            3600 |    0    ← 1h: never started
           86400 |    0    ← 1d: never started
```

The hang reproduces consistently because every backfill creates a fresh pool, so the second connection-acquire (after the 1m batch) hits PgBouncer's cache rejection.

## What this changes

```diff
-self._pool = await asyncpg.create_pool(self._dsn, init=_init_conn)
+self._pool = await asyncpg.create_pool(
+    self._dsn,
+    init=_init_conn,
+    statement_cache_size=0,
+    min_size=1,
+    max_size=4,
+    command_timeout=30,
+    timeout=10,
+)
```

## Test plan

- [x] `pytest -m "not live and not supabase"` — 170 passed
- [x] `ruff check .` — clean
- [ ] Manual: re-run `python -m scripts.backfill_bars --symbol QQQ` post-merge; verify all four `interval_seconds` rows populate in `bars` (60/300/3600/86400) and total elapsed is <30s

## Related

- Builds on #18 (multi-row VALUES batching). Both PRs needed for the full fix — #18 collapses round-trips, this PR makes the pool actually survive PgBouncer.

https://claude.ai/code/session_01T9xB5bMA2937np7Z8Tr3vj

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9xB5bMA2937np7Z8Tr3vj)_