### PR TITLE
fix(ibkr): feed factory honors cfg.broker.host/port instead of localhost

### DIFF
--- a/engine/data_feeds/factory.py
+++ b/engine/data_feeds/factory.py
@@ -20,8 +20,19 @@ def _make_yfinance_feed() -> MarketDataFeed:
     return YFinanceFeed()
 
 
-def make_feed(config: DataConfig) -> MarketDataFeed:
-    """Construct the equity feed selected by ``config.feed``."""
+def make_feed(
+    config: DataConfig,
+    *,
+    ibkr_host: str = "127.0.0.1",
+    ibkr_port: int = 7497,
+    ibkr_client_id: int = 17,
+) -> MarketDataFeed:
+    """Construct the equity feed selected by ``config.feed``.
+
+    The ``ibkr_*`` kwargs are forwarded to ``IBKRLiveFeed`` when ``feed`` is
+    ``ibkr_live``; ignored otherwise. They default to ib_insync's own defaults
+    so callers using non-IBKR feeds don't need to think about them.
+    """
     feed = config.feed
     if feed == "yfinance":
         return _make_yfinance_feed()
@@ -34,12 +45,17 @@ def make_feed(config: DataConfig) -> MarketDataFeed:
     if feed == "synthetic_options":
         return SyntheticOptionsFeed(_make_yfinance_feed())
     if feed == "ibkr_live":
-        return IBKRLiveFeed()
+        return IBKRLiveFeed(host=ibkr_host, port=ibkr_port, client_id=ibkr_client_id)
     raise ValueError(f"unknown feed: {feed!r}")  # pragma: no cover - Literal exhaustive
 
 
 def make_options_feed(
-    config: DataConfig, equity_feed: MarketDataFeed
+    config: DataConfig,
+    equity_feed: MarketDataFeed,
+    *,
+    ibkr_host: str = "127.0.0.1",
+    ibkr_port: int = 7497,
+    ibkr_client_id: int = 17,
 ) -> MarketDataFeed:
     """Construct the options feed selected by ``config.options_feed``.
 
@@ -53,7 +69,7 @@ def make_options_feed(
         # one IB connection (avoids "duplicate clientId" errors).
         if isinstance(equity_feed, IBKRLiveFeed):
             return equity_feed
-        return IBKRLiveFeed()
+        return IBKRLiveFeed(host=ibkr_host, port=ibkr_port, client_id=ibkr_client_id)
     raise ValueError(  # pragma: no cover - Literal exhaustive
         f"unknown options_feed: {options_feed!r}"
     )

--- a/services/strategy_engine/main.py
+++ b/services/strategy_engine/main.py
@@ -168,8 +168,22 @@ async def run(cfg: StrategyConfig) -> None:
     storage = _build_storage()
     writer = PersistenceWriter(storage)
 
-    equity_feed = make_feed(cfg.data)
-    options_feed = make_options_feed(cfg.data, equity_feed)
+    # Feed and broker share the same IB Gateway endpoint, but need different
+    # clientIds when both are connected (broker uses cfg.broker.client_id).
+    feed_client_id = cfg.broker.client_id + 1
+    equity_feed = make_feed(
+        cfg.data,
+        ibkr_host=cfg.broker.host,
+        ibkr_port=cfg.broker.port,
+        ibkr_client_id=feed_client_id,
+    )
+    options_feed = make_options_feed(
+        cfg.data,
+        equity_feed,
+        ibkr_host=cfg.broker.host,
+        ibkr_port=cfg.broker.port,
+        ibkr_client_id=feed_client_id,
+    )
     strategy = _build_strategy(cfg)
     risk = _build_risk_pipeline(cfg)
     broker = _build_broker(cfg)

--- a/tests/test_data_feeds/test_factory.py
+++ b/tests/test_data_feeds/test_factory.py
@@ -48,6 +48,29 @@ def test_make_feed_ibkr_live_returns_live_feed() -> None:
     assert isinstance(feed, IBKRLiveFeed)
 
 
+def test_make_feed_ibkr_live_threads_host_port_client_id() -> None:
+    from engine.data_feeds.ibkr_live import IBKRLiveFeed
+    feed = make_feed(
+        DataConfig(feed="ibkr_live"),
+        ibkr_host="ibkr-gateway.railway.internal",
+        ibkr_port=4002,
+        ibkr_client_id=18,
+    )
+    assert isinstance(feed, IBKRLiveFeed)
+    assert feed._host == "ibkr-gateway.railway.internal"
+    assert feed._port == 4002
+    assert feed._client_id == 18
+
+
+def test_make_feed_ibkr_live_defaults_match_ib_insync() -> None:
+    from engine.data_feeds.ibkr_live import IBKRLiveFeed
+    feed = make_feed(DataConfig(feed="ibkr_live"))
+    assert isinstance(feed, IBKRLiveFeed)
+    assert feed._host == "127.0.0.1"
+    assert feed._port == 7497
+    assert feed._client_id == 17
+
+
 def test_make_options_feed_synthetic() -> None:
     equity = YFinanceFeed()
     options = make_options_feed(DataConfig(options_feed="synthetic"), equity)
@@ -68,3 +91,21 @@ def test_make_options_feed_ibkr_live_reuses_equity_feed() -> None:
     equity = IBKRLiveFeed()
     options = make_options_feed(DataConfig(options_feed="ibkr_live"), equity)
     assert options is equity
+
+
+def test_make_options_feed_ibkr_live_threads_host_port_when_constructing() -> None:
+    """When equity feed is NOT IBKRLive, a fresh IBKRLiveFeed is constructed
+    with the supplied host/port/client_id."""
+    from engine.data_feeds.ibkr_live import IBKRLiveFeed
+    equity = YFinanceFeed()
+    options = make_options_feed(
+        DataConfig(options_feed="ibkr_live"),
+        equity,
+        ibkr_host="ibkr-gateway.railway.internal",
+        ibkr_port=4002,
+        ibkr_client_id=18,
+    )
+    assert isinstance(options, IBKRLiveFeed)
+    assert options._host == "ibkr-gateway.railway.internal"
+    assert options._port == 4002
+    assert options._client_id == 18


### PR DESCRIPTION
## Summary
- `IBKRLiveFeed` was constructed with no args in `factory.py`, so the feed always connected to ib_insync's defaults (`127.0.0.1:7497`).
- The broker correctly read `cfg.broker.host/port` from YAML, but the feed silently fell back to localhost — Phase-3 live deploys with `broker.host=ibkr-gateway.railway.internal` failed with `ECONNREFUSED`.
- Thread `ibkr_host` / `ibkr_port` / `ibkr_client_id` through `make_feed` and `make_options_feed`. `services/strategy_engine/main.py` now passes `cfg.broker.host/port` and `broker.client_id + 1` (so feed and broker can coexist on the same gateway when `dry_run=false` is flipped later).

## Repro (before this fix)
With `STRATEGY_CONFIG=./config/strategy.live.yaml` and `broker.host: ibkr-gateway.railway.internal`, strategy-engine logs:
```
ib_insync.client Connecting to 127.0.0.1:7497 with clientId 17...
ERROR API connection failed: ConnectionRefusedError(111, "Connect call failed ('127.0.0.1', 7497)")
```

## Cleanup (separate commit OK)
The Railway env vars `IBKR_HOST` / `IBKR_PORT` / `IBKR_CLIENT_ID` / `IBKR_TRADING_MODE` on `strategy-engine` were never read by any code. They can be removed for clarity.

## Test plan
- [x] `uv run pytest -n auto -m "not live and not supabase" -q` — 173 passed
- [x] `uv run ruff check .` — clean
- [x] New unit tests in `tests/test_data_feeds/test_factory.py`:
  - threads `host`/`port`/`client_id` into `IBKRLiveFeed` for both `make_feed` and `make_options_feed`
  - default args still match ib_insync defaults so existing call sites are unaffected
- [ ] Verify on Railway: redeploy `strategy-engine` from this branch and confirm logs show `Connecting to ibkr-gateway.railway.internal:4002 with clientId 18`

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_