### PR TITLE
fix(ibkr): keep USER as root in entrypoint wrapper so gnzsnz run.sh is readable

### DIFF
--- a/infra/ibkr/Dockerfile
+++ b/infra/ibkr/Dockerfile
@@ -25,6 +25,42 @@
 
 FROM gnzsnz/ib-gateway:stable
 
+# gnzsnz writes jts.ini with TrustedIPs=127.0.0.1, which makes IB Gateway
+# reject API connections from anything other than localhost. On Railway the
+# strategy-engine container reaches us via the private network, not 127.0.0.1,
+# so the gateway TCP-accepts then immediately closes the socket.
+#
+# Patch TrustedIPs=* once jts.ini exists. The container is only reachable on
+# Railway's private network (port 4002 is not publicly exposed), so widening
+# the allowlist here does not expose the API to the internet.
+#
+# Note: gnzsnz's entrypoint /root/scripts/run.sh is owned by root and is
+# read-only to other users; the wrapper must therefore stay USER root, the
+# same as the upstream image. Java/IB Gateway is launched under the
+# ibgateway user via su/gosu inside run.sh itself.
+RUN cat > /usr/local/bin/patch-trusted-ips.sh <<'EOF' && chmod +x /usr/local/bin/patch-trusted-ips.sh
+#!/usr/bin/env bash
+set -euo pipefail
+JTS_INI=/home/ibgateway/Jts/jts.ini
+for _ in {1..120}; do
+  if [ -f "$JTS_INI" ] && grep -q '^TrustedIPs=' "$JTS_INI"; then
+    if ! grep -q '^TrustedIPs=\*' "$JTS_INI"; then
+      sed -i 's|^TrustedIPs=.*|TrustedIPs=*|' "$JTS_INI"
+      echo "[patch-trusted-ips] set TrustedIPs=* in $JTS_INI"
+    fi
+    sleep 5
+    continue
+  fi
+  sleep 1
+done
+EOF
+
+# Wrap the gnzsnz entrypoint: kick off the patcher in the background, then
+# exec the upstream script. The patcher polls and rewrites jts.ini repeatedly
+# so a daily IBKR-forced relogin (which can regenerate the file) does not
+# silently restore TrustedIPs=127.0.0.1.
+ENTRYPOINT ["/bin/bash", "-c", "/usr/local/bin/patch-trusted-ips.sh & exec /root/scripts/run.sh \"$@\"", "--"]
+
 # Paper-trading port. We deliberately do NOT expose 4001 (live).
 EXPOSE 4002
 

--- a/infra/ibkr/Dockerfile
+++ b/infra/ibkr/Dockerfile
@@ -33,49 +33,33 @@ FROM gnzsnz/ib-gateway:stable
 # Patch TrustedIPs=* once jts.ini exists. The container is only reachable on
 # Railway's private network (port 4002 is not publicly exposed), so widening
 # the allowlist here does not expose the API to the internet.
-<<<<<<< HEAD
 #
 # Note: gnzsnz's entrypoint /root/scripts/run.sh is owned by root and is
 # read-only to other users; the wrapper must therefore stay USER root, the
 # same as the upstream image. Java/IB Gateway is launched under the
 # ibgateway user via su/gosu inside run.sh itself.
-=======
-USER root
->>>>>>> origin/main
 RUN cat > /usr/local/bin/patch-trusted-ips.sh <<'EOF' && chmod +x /usr/local/bin/patch-trusted-ips.sh
 #!/usr/bin/env bash
 set -euo pipefail
 JTS_INI=/home/ibgateway/Jts/jts.ini
+# Keep watching: gnzsnz/IBC may rewrite jts.ini on relogin.
 for _ in {1..120}; do
   if [ -f "$JTS_INI" ] && grep -q '^TrustedIPs=' "$JTS_INI"; then
     if ! grep -q '^TrustedIPs=\*' "$JTS_INI"; then
       sed -i 's|^TrustedIPs=.*|TrustedIPs=*|' "$JTS_INI"
       echo "[patch-trusted-ips] set TrustedIPs=* in $JTS_INI"
     fi
-<<<<<<< HEAD
-=======
-    # Keep watching: gnzsnz/IBC may rewrite jts.ini on relogin.
->>>>>>> origin/main
     sleep 5
     continue
   fi
   sleep 1
 done
 EOF
-<<<<<<< HEAD
 
 # Wrap the gnzsnz entrypoint: kick off the patcher in the background, then
 # exec the upstream script. The patcher polls and rewrites jts.ini repeatedly
 # so a daily IBKR-forced relogin (which can regenerate the file) does not
 # silently restore TrustedIPs=127.0.0.1.
-=======
-USER ibgateway
-
-# Wrap the original gnzsnz entrypoint: kick off the patcher in the background,
-# then exec the upstream startup. The patcher polls and rewrites jts.ini
-# repeatedly so a daily IBKR-forced relogin (which can regenerate the file)
-# does not silently restore TrustedIPs=127.0.0.1.
->>>>>>> origin/main
 ENTRYPOINT ["/bin/bash", "-c", "/usr/local/bin/patch-trusted-ips.sh & exec /root/scripts/run.sh \"$@\"", "--"]
 
 # Paper-trading port. We deliberately do NOT expose 4001 (live).


### PR DESCRIPTION
## Summary
Follow-up to #21. The previous PR's wrapper switched `USER` to `ibgateway` before exec'ing `/root/scripts/run.sh`, but that file is owned by root with no other-read. The container crash-looped:

```
/root/scripts/run.sh: Permission denied
exec: /root/scripts/run.sh: cannot execute: Permission denied
```

(repeating ~10x in the gateway logs)

gnzsnz's image runs the entrypoint as root and drops privileges to `ibgateway` internally (Java launches under su/gosu inside `run.sh`), so the wrapper needs to stay as root — matching upstream. The TrustedIPs patcher still touches `/home/ibgateway/Jts/jts.ini`, which root can write.

This PR re-applies the original #21 change but without the broken `USER ibgateway` line. The original Dockerfile changes from #21 were reverted in the working tree, so this is effectively a clean reapply of #21 + the user-switch fix.

## Test plan
- [ ] After merge: `git checkout main && git pull && railway up --detach --service ibkr-gateway`
- [ ] Wait ~2 min then `railway logs --service ibkr-gateway | tail -50` — expect IBC startup output, no `Permission denied` loop
- [ ] `railway logs --service ibkr-gateway | grep -iE 'patch-trusted-ips|trustedips'` — expect `[patch-trusted-ips] set TrustedIPs=* in /home/ibgateway/Jts/jts.ini`
- [ ] `railway logs --service strategy-engine | grep -iE 'ibkrlivefeed|connected|disconnect' | tail -10` — expect `Connected` followed by silence (no more 3ms-after-connect close)

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_