### PR TITLE
fix(ibkr): add USER root before RUN so build can write /usr/local/bin/

### DIFF
--- a/infra/ibkr/Dockerfile
+++ b/infra/ibkr/Dockerfile
@@ -34,10 +34,14 @@ FROM gnzsnz/ib-gateway:stable
 # Railway's private network (port 4002 is not publicly exposed), so widening
 # the allowlist here does not expose the API to the internet.
 #
-# Note: gnzsnz's entrypoint /root/scripts/run.sh is owned by root and is
-# read-only to other users; the wrapper must therefore stay USER root, the
-# same as the upstream image. Java/IB Gateway is launched under the
-# ibgateway user via su/gosu inside run.sh itself.
+# Note: gnzsnz/ib-gateway:stable ends with `USER ibgateway`, so RUN steps
+# in this Dockerfile execute as that unprivileged user by default and
+# cannot write to /usr/local/bin/. Switch to root for the build and stay
+# as root through runtime — gnzsnz's /root/scripts/run.sh is owned by
+# root and not other-readable, so the entrypoint MUST run as root too.
+# Java/IB Gateway is launched under the ibgateway user via su/gosu inside
+# run.sh itself, so end-user code still runs unprivileged.
+USER root
 RUN cat > /usr/local/bin/patch-trusted-ips.sh <<'EOF' && chmod +x /usr/local/bin/patch-trusted-ips.sh
 #!/usr/bin/env bash
 set -euo pipefail


### PR DESCRIPTION
## Summary
Build was failing on Railway:

```
/bin/sh: 1: cannot create /usr/local/bin/patch-trusted-ips.sh: Permission denied
Build Failed: build daemon returned an error ... exit code: 2
```

`gnzsnz/ib-gateway:stable` ends its Dockerfile with `USER ibgateway`, so derived Dockerfiles inherit that unprivileged user at build time and can't write to `/usr/local/bin/`.

## Why this iteration
- PR #21 added both `USER root` (for build) and `USER ibgateway` (for runtime) — build worked, runtime crashed because the entrypoint couldn't read `/root/scripts/run.sh`.
- PR #22 dropped both `USER` directives — runtime would have worked, but build failed because the upstream image's `USER ibgateway` was inherited.

This PR adds `USER root` only — root for both build and runtime. gnzsnz's `run.sh` drops privileges to `ibgateway` itself when launching Java via su/gosu, so end-user code still runs unprivileged.

## Test plan
- [ ] After merge: `git checkout main && git pull && railway up --detach --service ibkr-gateway`
- [ ] Build log: should NOT contain `Permission denied: cannot create /usr/local/bin/`
- [ ] Boot log: `railway logs --service ibkr-gateway | grep -iE 'patch-trusted-ips|login has completed|permission denied'`. Expect `[patch-trusted-ips] set TrustedIPs=*` + `Login has completed`, no `Permission denied`.
- [ ] Engine: `railway logs --service strategy-engine | grep -iE 'ibkrlivefeed|connected|disconnect' | tail -10` → `IBKRLiveFeed connected to ibkr-gateway.railway.internal:4002` followed by silence.

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_