### PR TITLE
fix(ibkr): patch TrustedIPs=127.0.0.1 at build time so gateway boots open

### DIFF
--- a/infra/ibkr/Dockerfile
+++ b/infra/ibkr/Dockerfile
@@ -59,16 +59,33 @@ RUN GNZSNZ_RUN_SH="$( \
     echo "[build] resolved gnzsnz entrypoint: $GNZSNZ_RUN_SH" && \
     echo "$GNZSNZ_RUN_SH" > /usr/local/etc/gnzsnz-run-sh.path
 
+# Patch every file under the image that hardcodes TrustedIPs=127.0.0.1
+# (the gnzsnz scripts and any jts.ini templates they ship with). IB Gateway
+# reads jts.ini once on startup and never reloads it, so changing the file
+# AFTER the gateway has started is too late — by then the in-memory
+# whitelist already says "only allow 127.0.0.1" and the connection from
+# the strategy-engine container gets dropped 3ms after TCP-accept.
+#
+# Doing this at build time means run.sh writes TrustedIPs=* into jts.ini
+# the very first time it runs, so the gateway boots with the right value.
+RUN grep -rln 'TrustedIPs=127\.0\.0\.1' / 2>/dev/null \
+      | while IFS= read -r f; do \
+          sed -i 's|TrustedIPs=127\.0\.0\.1|TrustedIPs=*|g' "$f" && \
+          echo "[build] patched TrustedIPs in $f"; \
+        done
+
 RUN cat > /usr/local/bin/patch-trusted-ips.sh <<'EOF' && chmod +x /usr/local/bin/patch-trusted-ips.sh
 #!/usr/bin/env bash
+# Belt-and-braces: keep watching jts.ini and re-apply TrustedIPs=* if a
+# daily IBKR-forced relogin or some unexpected codepath ever rewrites the
+# file with the old value. The build-time sed handles the common path.
 set -euo pipefail
 JTS_INI=/home/ibgateway/Jts/jts.ini
-# Keep watching: gnzsnz/IBC may rewrite jts.ini on relogin.
 for _ in {1..120}; do
   if [ -f "$JTS_INI" ] && grep -q '^TrustedIPs=' "$JTS_INI"; then
     if ! grep -q '^TrustedIPs=\*' "$JTS_INI"; then
       sed -i 's|^TrustedIPs=.*|TrustedIPs=*|' "$JTS_INI"
-      echo "[patch-trusted-ips] set TrustedIPs=* in $JTS_INI"
+      echo "[patch-trusted-ips] re-set TrustedIPs=* in $JTS_INI"
     fi
     sleep 5
     continue


### PR DESCRIPTION
## Summary
PR #24 successfully wires up the patcher and locates `run.sh`, but the engine connection still drops 3ms after `Connected`:

```
2026-05-09 06:24:45,716 INFO ib_insync.client Connected
2026-05-09 06:24:45,719 INFO ib_insync.client Disconnected.
```

Root cause: the runtime patcher sed's `jts.ini` AFTER gnzsnz's `run.sh` has already written it AND IB Gateway has already started. **The gateway reads `jts.ini` once on boot and never reloads it** — by the time the patcher runs, the in-memory whitelist already says "only 127.0.0.1" and any new connection gets dropped post-TCP-accept.

## Approach
Move the rewrite to **build time**: `grep -rln 'TrustedIPs=127.0.0.1' /` finds every file containing the literal string, then `sed` rewrites them to `TrustedIPs=*`. That catches the gnzsnz scripts and any jts.ini template the image ships with, so the very first time `run.sh` writes `jts.ini` at container start, it writes the open value.

The runtime patcher stays as belt-and-braces against any future codepath that regenerates the file (e.g. a daily IBKR-forced relogin), but should always be a no-op at boot now.

## Test plan
- [ ] After merge: `git checkout main && git pull && railway up --detach --service ibkr-gateway`
- [ ] Build log: expect one or more `[build] patched TrustedIPs in /<path>` lines
- [ ] Boot log: `railway logs --service ibkr-gateway | grep -iE 'trustedips|login has completed' | tail -10`. Expect either no `[patch-trusted-ips]` line at all (build-time fix did the job) or `[patch-trusted-ips] re-set TrustedIPs=*` after a relogin.
- [ ] Engine: `railway logs --service strategy-engine | grep -iE 'ibkrlivefeed|connected|disconnect' | tail -10` → `IBKRLiveFeed connected to ibkr-gateway.railway.internal:4002 (clientId=18, mktDataType=1)` followed by silence (no further `Disconnected.`).

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_