### PR TITLE
fix(engine): use acct.net_liquidation (not acct.nav) in broker heartbeat

### DIFF
--- a/services/strategy_engine/main.py
+++ b/services/strategy_engine/main.py
@@ -286,7 +286,7 @@ async def run(cfg: StrategyConfig) -> None:
                         "account_id": acct.account_id,
                         "broker_mode": cfg.broker.mode,
                         "dry_run": effective_dry_run,
-                        "nav": str(acct.nav),
+                        "nav": str(acct.net_liquidation),
                         "cash": str(acct.cash),
                         "buying_power": str(acct.buying_power),
                         "connected": True,


### PR DESCRIPTION
## Summary
The audit log was flooding with WARNs every 60s:

```
account_summary failed: 'AccountSummary' object has no attribute 'nav'
```

The IBKR connection is actually fine (TrustedIPs fix earlier in this session got us TCP-connected and the gateway is returning data). The bug is a field-name typo in the heartbeat:

- `contracts/broker.py:115` defines the field as `net_liquidation`
- `services/strategy_engine/main.py:289` was reading `acct.nav`

Every heartbeat fell through into the broker-error path, which made the /status page render "IBKR · Down" even though the gateway was healthy and reachable.

## Test plan
- [x] Local: `uv run pytest tests/test_broker tests/test_strategies -q` → 37 passed
- [ ] After merge: `git checkout main && git pull && railway up --detach --service strategy-engine`
- [ ] /audit page: no more `BROKER_ERROR  'AccountSummary' object has no attribute 'nav'` WARNs; instead an INFO line `BROKER_HEARTBEAT  ibkr account snapshot` every 60s
- [ ] /status page: IBKR gateway shows ●Healthy with NAV / Cash / Buying power populated

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_