### PR TITLE
fix(market-data-stream): forward broker host/port to IBKRLiveFeed

### DIFF
--- a/services/market_data_stream/main.py
+++ b/services/market_data_stream/main.py
@@ -35,7 +35,16 @@ def _build_storage() -> StorageBackend:
 async def run(cfg: StrategyConfig) -> None:
     LOG.info("starting market-data stream; feed=%s symbol=%s",
              cfg.data.feed, cfg.universe.symbol)
-    feed = make_feed(cfg.data)
+    # Feed and the strategy-engine's broker/feed share the same IB Gateway
+    # endpoint, so we forward cfg.broker.host/port. Each IBKR client needs
+    # a distinct clientId on the same gateway: broker=cfg.broker.client_id,
+    # engine feed=client_id+1, market-data-stream feed=client_id+2.
+    feed = make_feed(
+        cfg.data,
+        ibkr_host=cfg.broker.host,
+        ibkr_port=cfg.broker.port,
+        ibkr_client_id=cfg.broker.client_id + 2,
+    )
     writer = PersistenceWriter(_build_storage())
 
     stop_event = asyncio.Event()


### PR DESCRIPTION
## Summary
PR #20 fixed this exact bug for `strategy-engine`, but the same lurked in `market-data-stream`. `services/market_data_stream/main.py:38` called `make_feed(cfg.data)` with no host/port/client_id, so `IBKRLiveFeed` defaulted to `127.0.0.1:7497` + `clientId=17` — which can't reach `ibkr-gateway.railway.internal` from Railway's private network.

`feed.connect()` failed silently and the service fell into "heartbeat-only mode". That's why `/status` showed `market-data-stream: Healthy` (the heartbeat audit was firing every 60s) but no bars had persisted since Friday close — the bar-drain coroutine was stuck waiting for a feed that never came up.

## Fix
Forward `cfg.broker.host` / `cfg.broker.port` and use `client_id + 2`. The three IBKR clients on the same gateway now have distinct IDs:
- broker = `cfg.broker.client_id` (17)
- engine feed = `cfg.broker.client_id + 1` (18)
- market-data-stream feed = `cfg.broker.client_id + 2` (19)

## Test plan
- [x] Local: `uv run pytest tests/test_data_feeds -q` → 40 passed
- [ ] After merge: `git checkout main && git pull && railway up --detach --service market-data-stream`
- [ ] `railway logs --service market-data-stream | grep -iE 'connecting|connected|feed|bar' | tail -20` → expect `IBKRLiveFeed connected to ibkr-gateway.railway.internal:4002 (clientId=19, ...)` followed by NO `feed connect failed` errors
- [ ] /status page within ~5 min: `Bars persisted` flips to ●Healthy with a recent timestamp; `Live feed` arrival rate climbs from 0/min

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_