### PR TITLE
chore(audit): repr(exc) instead of str(exc) so FEED_CONNECT_FAILED shows type

### DIFF
--- a/services/market_data_stream/main.py
+++ b/services/market_data_stream/main.py
@@ -73,8 +73,10 @@ async def run(cfg: StrategyConfig) -> None:
             await feed.connect()
             feed_connected = True
         except Exception as exc:
-            LOG.error("feed connect failed: %s — heartbeat-only mode", exc)
-            await _audit("FEED_CONNECT_FAILED", "ERROR", str(exc))
+            # Use repr so audit captures the exception type even when the
+            # message is empty (e.g. asyncio.TimeoutError has no str repr).
+            LOG.error("feed connect failed: %r — heartbeat-only mode", exc)
+            await _audit("FEED_CONNECT_FAILED", "ERROR", repr(exc) or type(exc).__name__)
 
     await _audit("STARTUP", "INFO", "market-data stream started")
 

--- a/services/strategy_engine/main.py
+++ b/services/strategy_engine/main.py
@@ -198,9 +198,12 @@ async def run(cfg: StrategyConfig) -> None:
             feed_connected = True
             LOG.info("equity feed connected: %s", getattr(equity_feed, "name", "?"))
         except Exception as exc:
-            LOG.error("equity feed connect failed: %s — engine will idle", exc)
+            # Use repr so audit captures the exception type even when the
+            # message is empty (e.g. asyncio.TimeoutError has no str repr).
+            LOG.error("equity feed connect failed: %r — engine will idle", exc)
             await _audit(writer, "engine", "FEED_CONNECT_FAILED", "ERROR",
-                         str(exc), payload={"feed": cfg.data.feed})
+                         repr(exc) or type(exc).__name__,
+                         payload={"feed": cfg.data.feed})
 
     await _audit(writer, "engine", "STARTUP", "INFO",
                  f"engine started; feed={cfg.data.feed}", payload={


### PR DESCRIPTION
## Summary
Small diagnostic improvement. The /audit page is showing `FEED_CONNECT_FAILED` rows with an **empty** message column — because the code logs `str(exc)`, and `str(asyncio.TimeoutError())` is `""`. We can't tell from the audit alone whether the connection refused, timed out, or hit some other class of error.

`repr(exc)` gives `TimeoutError()` (or whatever the actual class is) which is at minimum enough to triage from the audit page without dropping into Railway logs.

Same treatment for the identical call site in `strategy-engine`.

## Test plan
- [ ] After merge, the next failure will write something like `repr=TimeoutError()` instead of `""` to the audit. We can then use that to figure out why market-data-stream is still failing to connect post-PR #28.

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_