### PR TITLE
fix(ibkr): force AcceptIncomingConnectionAction=accept so 2nd API client connects

### DIFF
--- a/infra/ibkr/Dockerfile
+++ b/infra/ibkr/Dockerfile
@@ -117,6 +117,32 @@ set -euo pipefail
 echo "[start-with-patcher] pre-run jts.ini contents:"
 cat /home/ibgateway/Jts/jts.ini 2>&1 | sed 's/^/[start-with-patcher]   /' || \
   echo "[start-with-patcher]   (no jts.ini yet)"
+
+# IBC's config.ini is the dialog-auto-dismiss controller. By default
+# AcceptIncomingConnectionAction is empty, which means IB Gateway pops
+# a "Accept incoming connection from X.X.X.X?" dialog for every new
+# API client IP and waits for a human click. In a headless container
+# that blocks forever, so the second API client always times out --
+# which is why market-data-stream's clientId=19 connection fails
+# even though strategy-engine's clientId=18 is healthy.
+#
+# Force AcceptIncomingConnectionAction=accept so IBC auto-dismisses
+# the dialog. gnzsnz writes /home/ibgateway/ibc/config.ini at startup
+# from its own template; we patch the file in-place after it appears.
+IBC_INI=/home/ibgateway/ibc/config.ini
+for _ in {1..30}; do
+  if [ -f "$IBC_INI" ]; then
+    if grep -q '^AcceptIncomingConnectionAction=' "$IBC_INI"; then
+      sed -i 's|^AcceptIncomingConnectionAction=.*|AcceptIncomingConnectionAction=accept|' "$IBC_INI"
+    else
+      echo 'AcceptIncomingConnectionAction=accept' >> "$IBC_INI"
+    fi
+    echo "[start-with-patcher] forced AcceptIncomingConnectionAction=accept in $IBC_INI"
+    break
+  fi
+  sleep 0.2
+done
+
 /usr/local/bin/patch-trusted-ips.sh &
 RUN_SH="$(cat /usr/local/etc/gnzsnz-run-sh.path 2>/dev/null || true)"
 if [ -z "$RUN_SH" ] || [ ! -x "$RUN_SH" ]; then


### PR DESCRIPTION
## Summary
market-data-stream (clientId=19) consistently times out 4s after TCP-accept with `API connection failed: TimeoutError()`, even though strategy-engine (clientId=18) is healthy on the same gateway. Gateway logs revealed the actual mechanic:

```
[start-with-patcher]   TrustedIPs=*                    ← our pre-bake
IBC: Found setting: [IBGateway]/TrustedIPs=*: updating value to 127.0.0.1
IBC:     jts.ini: TrustedIPs=127.0.0.1                 ← IBC rewrote it
```

**IBC validates TrustedIPs and silently forces it back to 127.0.0.1** — `*` isn't valid syntax. But the actual enforcement isn't `TrustedIPs`; strategy-engine connects fine anyway. What's blocking the 2nd client is the **"Accept incoming connection from X.X.X.X?"** dialog that IB Gateway pops for new client IPs. In a headless container that dialog blocks forever unless IBC's `AcceptIncomingConnectionAction` is set to `accept` (auto-click Yes). It was empty (= manual) in our gnzsnz image.

The repo already had a template at `infra/ibkr/ibc-config.ini.template` with `AcceptIncomingConnectionAction=accept` on line 19, but the Dockerfile never copied it into place.

## Fix
Patch `/home/ibgateway/ibc/config.ini` at container start, after gnzsnz's `run.sh` creates the file but before IBC reads it. The wrapper polls for the file (~0.2s intervals, up to 6s), then either sed-rewrites the existing line or appends if it's missing.

## Test plan
- [ ] After merge: `railway up --detach --service ibkr-gateway`, wait ~2 min for boot
- [ ] `railway logs --service ibkr-gateway | grep -iE 'forced acceptincoming|acceptincomingconnection'` → expect `[start-with-patcher] forced AcceptIncomingConnectionAction=accept in /home/ibgateway/ibc/config.ini` + IBC's settings dump showing `AcceptIncomingConnectionAction=accept` (not empty)
- [ ] `railway up --detach --service market-data-stream` and wait ~90s
- [ ] `railway logs --service market-data-stream | grep -iE 'connect|fail|error|clientid' | tail -10` → expect `Connecting to ibkr-gateway.railway.internal:4002 with clientId 19` followed by `Connected` and **no** further `Disconnected.` or `TimeoutError()`
- [ ] /status: `Bars persisted` flips to ●Healthy; `Live feed` arrival rate climbs from `0/min`

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_