### PR TITLE
fix(ibkr): force TrustedTwsApiClientIPs=0.0.0.0 to allow Railway private-network clients

### DIFF
--- a/infra/ibkr/Dockerfile
+++ b/infra/ibkr/Dockerfile
@@ -118,26 +118,37 @@ echo "[start-with-patcher] pre-run jts.ini contents:"
 cat /home/ibgateway/Jts/jts.ini 2>&1 | sed 's/^/[start-with-patcher]   /' || \
   echo "[start-with-patcher]   (no jts.ini yet)"
 
-# IBC's config.ini is the dialog-auto-dismiss controller. By default
-# AcceptIncomingConnectionAction is empty, which means IB Gateway pops
-# a "Accept incoming connection from X.X.X.X?" dialog for every new
-# API client IP and waits for a human click. In a headless container
-# that blocks forever, so the second API client always times out --
-# which is why market-data-stream's clientId=19 connection fails
-# even though strategy-engine's clientId=18 is healthy.
+# IBC's config.ini controls two things we care about:
 #
-# Force AcceptIncomingConnectionAction=accept so IBC auto-dismisses
-# the dialog. gnzsnz writes /home/ibgateway/ibc/config.ini at startup
-# from its own template; we patch the file in-place after it appears.
+# 1. AcceptIncomingConnectionAction -- when empty (gnzsnz's default),
+#    IB Gateway pops a "Accept incoming connection from X.X.X.X?"
+#    dialog for every new API client IP and waits for a human click.
+#    In a headless container that blocks. Setting "accept" auto-clicks
+#    Yes.
+#
+# 2. TrustedTwsApiClientIPs -- when empty, IBC defaults the gateway's
+#    TrustedIPs to just 127.0.0.1, blocking everything from Railway's
+#    private network. IBC's own docs say setting this to "0.0.0.0"
+#    allows connections from any IP. The wildcard "*" gets validated
+#    and rewritten back to 127.0.0.1; "0.0.0.0" is the documented
+#    "allow all" sentinel that survives IBC's validation.
+#
+# gnzsnz writes config.ini at startup from its own template. We patch
+# the file in-place after it appears but before gnzsnz exec's IBC.
 IBC_INI=/home/ibgateway/ibc/config.ini
+_ibc_force_setting() {
+  local key="$1" val="$2"
+  if grep -q "^${key}=" "$IBC_INI"; then
+    sed -i "s|^${key}=.*|${key}=${val}|" "$IBC_INI"
+  else
+    echo "${key}=${val}" >> "$IBC_INI"
+  fi
+  echo "[start-with-patcher] forced ${key}=${val} in $IBC_INI"
+}
 for _ in {1..30}; do
   if [ -f "$IBC_INI" ]; then
-    if grep -q '^AcceptIncomingConnectionAction=' "$IBC_INI"; then
-      sed -i 's|^AcceptIncomingConnectionAction=.*|AcceptIncomingConnectionAction=accept|' "$IBC_INI"
-    else
-      echo 'AcceptIncomingConnectionAction=accept' >> "$IBC_INI"
-    fi
-    echo "[start-with-patcher] forced AcceptIncomingConnectionAction=accept in $IBC_INI"
+    _ibc_force_setting AcceptIncomingConnectionAction accept
+    _ibc_force_setting TrustedTwsApiClientIPs 0.0.0.0
     break
   fi
   sleep 0.2


### PR DESCRIPTION
## Summary
After PR #30 set `AcceptIncomingConnectionAction=accept` via the `TWS_ACCEPT_INCOMING` env var, market-data-stream still times out 4s after TCP-accept. Same pattern for strategy-engine's feed — **both clients on Railway's private network never actually connect to the gateway**. The dialog-auto-dismiss theory was wrong: the rejection happens at the TCP layer ~1ms after accept, way before any dialog would fire.

The real gate is IBC's `TrustedTwsApiClientIPs` setting in `config.ini`. When empty, IBC writes `jts.ini`'s `TrustedIPs=127.0.0.1` — which blocks every connection from Railway's container subnet. Setting it to `*` doesn't work (IBC validates and rewrites it back to `127.0.0.1`). But per IBC's own docs:

> If `TrustedTwsApiClientIPs` is left empty, only connections from localhost are allowed. **You can include `0.0.0.0` to allow connections from any IP address (less secure).**

`0.0.0.0` is the documented "allow all" sentinel that survives IBC's validation.

gnzsnz doesn't expose an env var for this (`TWS_TRUSTED_IPS` does nothing — empirically confirmed by setting it on Railway and watching `TrustedTwsApiClientIPs=` stay empty in the IBC dump). So we patch `config.ini` directly in our wrapper — same pattern that worked for `AcceptIncomingConnectionAction`. Refactor the duplicated patch logic into a small bash function while I'm in there.

## Security note
`0.0.0.0` allows any source IP, but the gateway container only listens on Railway's **private** internal network (port 4002 is never publicly exposed — Railway's runtime enforces this for unexposed services). The blast radius is "any container in your Railway project", which is the model we want anyway.

## Test plan
- [ ] After merge: `railway up --detach --service ibkr-gateway`, wait ~2 min
- [ ] `railway logs --service ibkr-gateway | grep -iE 'TrustedTwsApiClientIPs|TrustedIPs' | tail -10` → expect `TrustedTwsApiClientIPs=0.0.0.0` (not empty)
- [ ] `railway up --detach --service market-data-stream`, wait ~90s
- [ ] `railway logs --service market-data-stream | grep -iE 'connect|fail|timeout' | tail -10` → expect `Connected` followed by silence (no `Disconnected.`, no `TimeoutError()`)
- [ ] `railway up --detach --service strategy-engine`, wait ~90s — same check (its feed connect should now succeed)
- [ ] /status: `Bars persisted` ●Healthy, `Live feed` arrival rate climbing

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_