### PR TITLE
fix(ibkr): aggressive 50ms watcher to force TrustedTwsApiClientIPs through gnzsnz overwrite

### DIFF
--- a/infra/ibkr/Dockerfile
+++ b/infra/ibkr/Dockerfile
@@ -90,22 +90,63 @@ RUN chown -R ibgateway:ibgateway /home/ibgateway/Jts && \
 
 RUN cat > /usr/local/bin/patch-trusted-ips.sh <<'EOF' && chmod +x /usr/local/bin/patch-trusted-ips.sh
 #!/usr/bin/env bash
-# Belt-and-braces: keep watching jts.ini and re-apply TrustedIPs=* if a
-# daily IBKR-forced relogin or some unexpected codepath ever rewrites the
-# file with the old value. The build-time pre-bake handles the common
-# path; this watcher is just a safety net.
+# Aggressive background watcher: keep jts.ini and IBC's config.ini set
+# to the values we want. Necessary because gnzsnz's run.sh writes both
+# files AFTER our pre-startup patch in start-with-patcher.sh and BEFORE
+# IBC reads them, silently clobbering our values. We need to repatch
+# fast enough to win the race against IBC's startup config-read.
+#
+# Poll at 50 ms for the first 60 s, then back off to 5 s as a safety net.
 set -euo pipefail
 JTS_INI=/home/ibgateway/Jts/jts.ini
-for _ in {1..120}; do
+IBC_INI=/home/ibgateway/ibc/config.ini
+
+_force_jts_trustedips() {
   if [ -f "$JTS_INI" ] && grep -q '^TrustedIPs=' "$JTS_INI"; then
     if ! grep -q '^TrustedIPs=\*' "$JTS_INI"; then
       sed -i 's|^TrustedIPs=.*|TrustedIPs=*|' "$JTS_INI"
       echo "[patch-trusted-ips] re-set TrustedIPs=* in $JTS_INI"
     fi
-    sleep 5
-    continue
   fi
-  sleep 1
+}
+
+_force_ibc_trusted_clients() {
+  [ -f "$IBC_INI" ] || return 0
+  if grep -q '^TrustedTwsApiClientIPs=' "$IBC_INI"; then
+    if ! grep -q '^TrustedTwsApiClientIPs=0\.0\.0\.0' "$IBC_INI"; then
+      sed -i 's|^TrustedTwsApiClientIPs=.*|TrustedTwsApiClientIPs=0.0.0.0|' "$IBC_INI"
+      echo "[patch-trusted-ips] re-set TrustedTwsApiClientIPs=0.0.0.0 in $IBC_INI"
+    fi
+  else
+    echo 'TrustedTwsApiClientIPs=0.0.0.0' >> "$IBC_INI"
+    echo "[patch-trusted-ips] appended TrustedTwsApiClientIPs=0.0.0.0 to $IBC_INI"
+  fi
+  if grep -q '^AcceptIncomingConnectionAction=' "$IBC_INI"; then
+    if ! grep -q '^AcceptIncomingConnectionAction=accept' "$IBC_INI"; then
+      sed -i 's|^AcceptIncomingConnectionAction=.*|AcceptIncomingConnectionAction=accept|' "$IBC_INI"
+      echo "[patch-trusted-ips] re-set AcceptIncomingConnectionAction=accept in $IBC_INI"
+    fi
+  else
+    echo 'AcceptIncomingConnectionAction=accept' >> "$IBC_INI"
+    echo "[patch-trusted-ips] appended AcceptIncomingConnectionAction=accept to $IBC_INI"
+  fi
+}
+
+# Tight loop for the first 60 s -- this is where the race with IBC's
+# startup read happens.
+end=$(( $(date +%s) + 60 ))
+while [ "$(date +%s)" -lt "$end" ]; do
+  _force_jts_trustedips
+  _force_ibc_trusted_clients
+  sleep 0.05
+done
+
+# After IBC is up, slow-poll as a safety net for relogins that
+# regenerate the files.
+while true; do
+  _force_jts_trustedips
+  _force_ibc_trusted_clients
+  sleep 5
 done
 EOF
 


### PR DESCRIPTION
## Summary
PR #31's pre-startup patcher does write `TrustedTwsApiClientIPs=0.0.0.0` into IBC's config.ini, but gnzsnz's `run.sh` then **rewrites the file from its own template AFTER our patch and BEFORE IBC reads it**, clobbering our value back to empty:

```
[start-with-patcher] forced TrustedTwsApiClientIPs=0.0.0.0
    TrustedTwsApiClientIPs=                ← IBC dump still empty
```

The `AcceptIncomingConnectionAction=accept` value survives only because gnzsnz reads `TWS_ACCEPT_INCOMING` env var and writes the value itself. **No equivalent env var exists for `TrustedTwsApiClientIPs`** — `TWS_TRUSTED_IPS` does nothing (confirmed empirically last round).

## Approach
Switch the existing background patcher from a slow 5 s poll to a **tight 50 ms poll for the first 60 s**, which is the window covering gnzsnz's config write and the racing IBC read. After 60 s, fall back to a 5 s safety-net poll for relogin regenerations.

While in there, extend the watcher to also keep `AcceptIncomingConnectionAction=accept` set — the env-var path would silently break if anyone removed `TWS_ACCEPT_INCOMING`, and the marginal cost is one extra sed.

## Test plan
- [ ] After merge: `railway up --detach --service ibkr-gateway`, wait ~2 min
- [ ] `railway logs --service ibkr-gateway | grep -iE 'TrustedTwsApiClientIPs|TrustedIPs|patch-trusted' | tail -20` → expect at least one `[patch-trusted-ips] re-set TrustedTwsApiClientIPs=0.0.0.0` line (the watcher catching gnzsnz's clobber) AND IBC's dump showing `TrustedTwsApiClientIPs=0.0.0.0` (not empty)
- [ ] `railway up --detach --service market-data-stream`, wait ~90 s
- [ ] `railway logs --service market-data-stream | grep -iE 'connect|timeout|fail' | tail -10` → expect `Connected` followed by silence (no `TimeoutError()`)

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_