### PR TITLE
fix(ibkr): stop overwriting jts.ini's TrustedIPs with invalid `*`

### DIFF
--- a/infra/ibkr/Dockerfile
+++ b/infra/ibkr/Dockerfile
@@ -102,12 +102,16 @@ JTS_INI=/home/ibgateway/Jts/jts.ini
 IBC_INI=/home/ibgateway/ibc/config.ini
 
 _force_jts_trustedips() {
-  if [ -f "$JTS_INI" ] && grep -q '^TrustedIPs=' "$JTS_INI"; then
-    if ! grep -q '^TrustedIPs=\*' "$JTS_INI"; then
-      sed -i 's|^TrustedIPs=.*|TrustedIPs=*|' "$JTS_INI"
-      echo "[patch-trusted-ips] re-set TrustedIPs=* in $JTS_INI"
-    fi
-  fi
+  # IBC validates jts.ini's TrustedIPs and rewrites invalid values to
+  # 127.0.0.1. With our TrustedTwsApiClientIPs=0.0.0.0 in config.ini,
+  # IBC writes TrustedIPs=127.0.0.1,0.0.0.0 which is a VALID value
+  # ("0.0.0.0" is IBC's documented sentinel for allow-all). Earlier
+  # this watcher overwrote IBC's good value with `*` -- which IBC then
+  # had to rewrite to 127.0.0.1 again, and may have left the file in
+  # an invalid state while the gateway was reading it (Java loaded `*`,
+  # treated it as no-match, never opened the API socket). Just leave
+  # IBC's value alone; no patching needed here.
+  return 0
 }
 
 _force_ibc_trusted_clients() {


### PR DESCRIPTION
## Summary
The 50 ms watcher introduced in PR #32 keeps sed'ing `jts.ini → TrustedIPs=*` — but `*` is **invalid** syntax. IBC explicitly rejects it and rewrites to `127.0.0.1`. So our watcher and IBC are racing on every poll, leaving jts.ini in inconsistent states.

When the Java gateway reads jts.ini during boot, if it samples our `*` value before IBC's correction, it loads "no IPs matching" and **never opens the API socket**. That's the most likely explanation for the recent symptom:

- Gateway boots cleanly through all dialogs
- `Pending Tasks: Closed`
- **Then radio silence** — no `API server listening on port` line ever appears
- Client TCP connections get accepted (by socat) then immediately closed (no API backend listening to handshake)

With our `TrustedTwsApiClientIPs=0.0.0.0` in config.ini (from PR #31/32), IBC writes `TrustedIPs=127.0.0.1,0.0.0.0` to jts.ini — which IS a valid value (`0.0.0.0` is IBC's documented allow-all sentinel). No further patching needed; the previous patcher was actively breaking the gateway.

This PR makes `_force_jts_trustedips` a no-op. The IBC-side patcher (`_force_ibc_trusted_clients`) stays in place — it's only the jts.ini side that was destructive.

## Test plan
- [ ] After merge: `railway up --detach --service ibkr-gateway`, wait ~3 min
- [ ] `railway logs --service ibkr-gateway | grep -iE "API server listening|TrustedIPs|Pending Tasks" | tail -10` → expect **`API server listening on port 7497`** (this is the line we've been missing for the past 8+ deploys)
- [ ] `railway up --detach --service market-data-stream`, wait ~90 s
- [ ] `railway logs --service market-data-stream | grep -iE "connect|timeout|fail" | tail -10` → expect `Connected` followed by silence (no `TimeoutError()`)

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_