### PR TITLE
fix(ibkr): connect to socat port 4004, not gateway port 4002

### DIFF
--- a/config/strategy.live.yaml
+++ b/config/strategy.live.yaml
@@ -19,7 +19,14 @@ broker:
   name: ibkr
   mode: paper
   host: ibkr-gateway.railway.internal   # Railway private DNS
-  port: 4002                             # IB Gateway paper port (gnzsnz image)
+  # gnzsnz/ib-gateway runs IB Gateway on port 4002 (the API itself, bound
+  # to all interfaces) AND socat on port 4004 (which forwards to localhost:4002).
+  # If we connect to 4002 directly we hit the gateway with the client's
+  # actual source IP -- the gateway then fails its TrustedIPs check and
+  # closes the connection 1ms after accept. Connecting to 4004 routes
+  # through socat, so the gateway sees 127.0.0.1 as the source IP and
+  # the TrustedIPs check passes.
+  port: 4004                             # SOCAT_PORT (proxy to localhost:4002)
   client_id: 17
   dry_run: true                          # KEEP TRUE during the first session
   # IBKR paper accounts start with DU; the existing PaperAccountGuard already


### PR DESCRIPTION
## Summary
gnzsnz's image runs **two listeners**:
- **IB Gateway on 4002** (bound to 0.0.0.0 — all interfaces)
- **socat on 4004** forwarding to localhost:4002

Our config has clients connecting to 4002 — which **bypasses socat and hits the gateway directly**. The gateway sees the client's actual Railway container IP as the source, fails its `TrustedIPs=127.0.0.1,0.0.0.0` check (`0.0.0.0` is NOT treated as wildcard by IB Gateway, only by IBC's config layer), and slams the connection closed 1ms after TCP accept.

That's the persistent `Connected → Disconnected. (1ms) → TimeoutError()` pattern we've been chasing across `market-data-stream` and `strategy-engine` — despite many rounds of IBC config fixes that were doing the right thing but pointing at the wrong port.

Connecting to **4004** routes through socat. socat's outbound connection to localhost:4002 gives the gateway a `127.0.0.1` source IP, which IS in `TrustedIPs`. Connection accepted, handshake completes normally.

## Discovery
PR #33 finally got the gateway booting cleanly through all dialogs, but connections still failed. The gateway log showed:
```
API_PORT set to: 4002
SOCAT_PORT set to: 4004
Forking :::4002 onto 0.0.0.0:4004
```
A careful re-read showed the port topology. Clients should have been on `SOCAT_PORT` (4004) all along.

## Test plan
- [ ] After merge: redeploy strategy-engine + market-data-stream (they pick up the new YAML)
- [ ] `railway up --detach --service market-data-stream && sleep 90 && railway logs --service market-data-stream | grep -iE 'connect|timeout|fail|error' | tail -10` → expect **`Connected` followed by silence** (no `Disconnected.` or `TimeoutError()`)
- [ ] /status: `Bars persisted` ●Healthy, `Live feed` arrival rate > 0/min
- [ ] /status: `Latest signal` updates when an SMA9/VWAP cross fires (market hours)

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_