### PR TITLE
fix(ibkr): default to delayed market data so feed works without paid API subscription

### DIFF
--- a/config/schema.py
+++ b/config/schema.py
@@ -30,6 +30,10 @@ class DataConfig(_Strict):
     bar_interval_seconds: int = 60
     options_feed: OptionsFeedName = "synthetic"
     replay_path: str | None = None  # required if feed == replay
+    # IBKR reqMarketDataType: 1=live (requires API-eligible subscription),
+    # 3=delayed (15-min lag, free). Default to delayed so the feed works
+    # out of the box; bump to 1 when you have a real-time API subscription.
+    market_data_type: Literal[1, 2, 3, 4] = 3
 
 
 class BrokerConfig(_Strict):

--- a/engine/data_feeds/factory.py
+++ b/engine/data_feeds/factory.py
@@ -45,7 +45,12 @@ def make_feed(
     if feed == "synthetic_options":
         return SyntheticOptionsFeed(_make_yfinance_feed())
     if feed == "ibkr_live":
-        return IBKRLiveFeed(host=ibkr_host, port=ibkr_port, client_id=ibkr_client_id)
+        return IBKRLiveFeed(
+            host=ibkr_host,
+            port=ibkr_port,
+            client_id=ibkr_client_id,
+            market_data_type=config.market_data_type,
+        )
     raise ValueError(f"unknown feed: {feed!r}")  # pragma: no cover - Literal exhaustive
 
 
@@ -69,7 +74,12 @@ def make_options_feed(
         # one IB connection (avoids "duplicate clientId" errors).
         if isinstance(equity_feed, IBKRLiveFeed):
             return equity_feed
-        return IBKRLiveFeed(host=ibkr_host, port=ibkr_port, client_id=ibkr_client_id)
+        return IBKRLiveFeed(
+            host=ibkr_host,
+            port=ibkr_port,
+            client_id=ibkr_client_id,
+            market_data_type=config.market_data_type,
+        )
     raise ValueError(  # pragma: no cover - Literal exhaustive
         f"unknown options_feed: {options_feed!r}"
     )

--- a/engine/data_feeds/ibkr_live.py
+++ b/engine/data_feeds/ibkr_live.py
@@ -57,18 +57,30 @@ class IBKRLiveFeed(BaseFeed):
 
     name: str = "ibkr_live"
 
-    LIVE_MARKET_DATA_TYPE: int = 1   # 1=live, 2=frozen, 3=delayed, 4=delayed-frozen
     GENERIC_TICK_GREEKS: str = "106"  # OptionImpliedVolatility + Greeks
+
+    # reqMarketDataType values per IBKR API:
+    #   1 = live (requires API-eligible market-data subscription)
+    #   2 = frozen (last live snapshot, no updates)
+    #   3 = delayed (15-min lag, free; works when no live subscription)
+    #   4 = delayed-frozen
+    # We default to 3 so the feed works out of the box for IBKR paper
+    # accounts and lite plans. Override via cfg.data.market_data_type when
+    # you have a real API-eligible streaming subscription.
+    MARKET_DATA_TYPE_LIVE: int = 1
+    MARKET_DATA_TYPE_DELAYED: int = 3
 
     def __init__(
         self,
         host: str = "127.0.0.1",
         port: int = 7497,
         client_id: int = 17,
+        market_data_type: int = MARKET_DATA_TYPE_DELAYED,
     ) -> None:
         self._host = host
         self._port = port
         self._client_id = client_id
+        self._market_data_type = market_data_type
         self._ib: Any = None
         self._connected: bool = False
         self._data_type_returned: int | None = None
@@ -83,11 +95,11 @@ class IBKRLiveFeed(BaseFeed):
 
         self._ib = IB()
         await self._ib.connectAsync(self._host, self._port, clientId=self._client_id)
-        self._ib.reqMarketDataType(self.LIVE_MARKET_DATA_TYPE)
+        self._ib.reqMarketDataType(self._market_data_type)
         self._connected = True
         logger.info(
             "IBKRLiveFeed connected to %s:%s (clientId=%s, mktDataType=%s)",
-            self._host, self._port, self._client_id, self.LIVE_MARKET_DATA_TYPE,
+            self._host, self._port, self._client_id, self._market_data_type,
         )
 
     async def disconnect(self) -> None:


### PR DESCRIPTION
## Summary
After **all** the connectivity fixes (PRs #20 through #34) finally worked, market-data-stream now reaches the gateway cleanly — and we hit a new IBKR-specific gotcha:

```
Error 420: No market data permissions for ISLAND STK. Requested market
  data requires additional subscription for API.
Error 10089: ... Delayed market data is available.
```

The user's account has a perfectly good streaming-quote subscription (`US Real-Time Non Consolidated Streaming Quotes`, `US Securities Snapshot Bundle`). But IBKR licenses those for the **TWS desktop app**; third-party API clients need a separate "API L1" line item to get the same live feed. (Annoying. Not fixable from code.)

The same error message confirms IBKR will hand out **delayed (15-min lag) data for free** when we request `mktDataType=3`. For dry-run / backtest validation that's totally adequate — the SMA9/VWAP cross strategy detects the same crosses, just 15 minutes later than wall-clock.

## Approach
- Add `market_data_type: Literal[1, 2, 3, 4] = 3` to `DataConfig` schema (default to delayed)
- `IBKRLiveFeed.__init__` takes the value and calls `reqMarketDataType` with it
- Factory pipes `config.market_data_type` through to both equity + options feed paths
- Default is `3` (delayed) so the feed works out of the box on any IBKR paper account / Lite plan
- When the user gets a real API-eligible subscription, flipping `market_data_type: 1` in `strategy.live.yaml` restores live data

## Test plan
- [x] `uv run pytest tests/test_data_feeds tests/test_strategies -q` → 62 passed
- [ ] After merge: `railway up --detach --service market-data-stream && railway up --detach --service strategy-engine`
- [ ] `railway logs --service market-data-stream | grep -iE "error 420|error 10089|mktDataType|bar" | tail -10` → expect NO `Error 420` / `Error 10089`, see `mktDataType=3` in connect log
- [ ] /status: `Bars persisted` ●Healthy, `Live feed` arrival rate climbs from 0/min (markets are still open until 20:00 UTC)

## Followups (not blocking)
- `Error 321: Read-Only mode` from ib_insync auto-fetching open orders — cosmetic; can be silenced by setting `READ_ONLY_API=no` Railway env var on `ibkr-gateway`
- If you decide to pay for an API-eligible market data subscription, bump `market_data_type: 1` in `config/strategy.live.yaml`

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_