### PR TITLE
fix(ibkr): route market-data requests to primary exchange (NASDAQ for QQQ) not SMART

### DIFF
--- a/engine/data_feeds/ibkr_live.py
+++ b/engine/data_feeds/ibkr_live.py
@@ -60,6 +60,25 @@ class IBKRLiveFeed(BaseFeed):
     LIVE_MARKET_DATA_TYPE: int = 1   # 1=live, 2=frozen, 3=delayed, 4=delayed-frozen
     GENERIC_TICK_GREEKS: str = "106"  # OptionImpliedVolatility + Greeks
 
+    # Market-data routing: SMART picks an arbitrary ATS (e.g. ISLAND for
+    # NASDAQ-listed names), and IBKR's per-ATS subscription check rejects
+    # the request unless you've paid for that specific venue's depth.
+    # Forcing the primary listing exchange targets the consolidated tape
+    # which the "US Equity and Options Add-On Streaming Bundle (NP)"
+    # subscription covers for NYSE/AMEX/NASDAQ. Order placement (in
+    # ibkr_paper.py) stays SMART for best execution -- only the
+    # market-data subscription is venue-sensitive.
+    PRIMARY_EXCHANGE: dict[str, str] = {
+        "QQQ": "NASDAQ",
+        "SPY": "ARCA",
+        "IWM": "ARCA",
+        "DIA": "ARCA",
+    }
+
+    @classmethod
+    def _market_data_exchange(cls, symbol: str) -> str:
+        return cls.PRIMARY_EXCHANGE.get(symbol.upper(), "SMART")
+
     def __init__(
         self,
         host: str = "127.0.0.1",
@@ -111,7 +130,7 @@ class IBKRLiveFeed(BaseFeed):
         except ImportError as exc:  # pragma: no cover
             raise RuntimeError("ib_insync is required for IBKRLiveFeed") from exc
 
-        contract = Stock(sym, "SMART", "USD")
+        contract = Stock(sym, self._market_data_exchange(sym), "USD")
         ticker = ib.reqMktData(contract, "", False, False)
         try:
             while True:
@@ -146,7 +165,7 @@ class IBKRLiveFeed(BaseFeed):
         except ImportError as exc:  # pragma: no cover
             raise RuntimeError("ib_insync is required for IBKRLiveFeed") from exc
 
-        contract = Stock(sym, "SMART", "USD")
+        contract = Stock(sym, self._market_data_exchange(sym), "USD")
         bars = ib.reqRealTimeBars(contract, 5, "TRADES", False)
         agg_seconds = max(interval_seconds, 5)
         ratio = agg_seconds // 5
@@ -200,7 +219,7 @@ class IBKRLiveFeed(BaseFeed):
             raise RuntimeError("ib_insync is required for IBKRLiveFeed") from exc
 
         # Get the underlying contract id needed by reqSecDefOptParams
-        underlying_contract = Stock(sym, "SMART", "USD")
+        underlying_contract = Stock(sym, self._market_data_exchange(sym), "USD")
         await ib.qualifyContractsAsync(underlying_contract)
         params_list = await ib.reqSecDefOptParamsAsync(
             underlying_contract.symbol, "", "STK", underlying_contract.conId

--- a/engine/data_feeds/ibkr_live.py
+++ b/engine/data_feeds/ibkr_live.py
@@ -24,7 +24,7 @@ import logging
 from collections.abc import AsyncIterator
 from datetime import UTC, date, datetime
 from decimal import Decimal
-from typing import Any
+from typing import Any, ClassVar
 
 from contracts.data_feed import (
     Bar,
@@ -68,7 +68,7 @@ class IBKRLiveFeed(BaseFeed):
     # subscription covers for NYSE/AMEX/NASDAQ. Order placement (in
     # ibkr_paper.py) stays SMART for best execution -- only the
     # market-data subscription is venue-sensitive.
-    PRIMARY_EXCHANGE: dict[str, str] = {
+    PRIMARY_EXCHANGE: ClassVar[dict[str, str]] = {
         "QQQ": "NASDAQ",
         "SPY": "ARCA",
         "IWM": "ARCA",


### PR DESCRIPTION
## Summary
After PR #34 unblocked the IBKR gateway connection, market-data-stream finally got an API handshake but immediately failed with:

```
Error 420: No market data permissions for ISLAND STK
  contract: Stock(symbol='QQQ', exchange='SMART', currency='USD')
```

SMART routing picked **ISLAND** (NASDAQ's matching ATS) for QQQ. The user IS subscribed to `US Equity and Options Add-On Streaming Bundle (NP)` which covers NASDAQ (Network C/UTP) — but the subscription targets the **consolidated NASDAQ tape**, not the per-ATS feed for ISLAND specifically. IBKR enforces this distinction strictly for API clients.

## Fix
Force market-data requests to the primary listing exchange (`NASDAQ` for QQQ, `ARCA` for SPY/IWM/DIA) which uses the consolidated tape and matches the streaming-bundle subscription:

```python
PRIMARY_EXCHANGE = {
    "QQQ": "NASDAQ",
    "SPY": "ARCA",
    "IWM": "ARCA",
    "DIA": "ARCA",
}
```

Order placement (`ibkr_paper.py`) is **untouched** — SMART is still correct for execution routing because IBKR doesn't care about subscription venue when sending orders.

If a different symbol is added later that's not in the mapping, it falls back to SMART → would hit Error 420 again → add to mapping.

## Test plan
- [x] Local: `uv run pytest tests/test_data_feeds tests/test_strategies -q` → 62 passed
- [ ] After merge: `railway up --detach --service market-data-stream && railway up --detach --service strategy-engine`
- [ ] `railway logs --service market-data-stream | grep -iE "error 420|error 10089|connecting|connected" | tail -10` → expect NO `Error 420` / `Error 10089`
- [ ] /status: `Bars persisted` ●Healthy, `Live feed` arrival rate climbing (markets close at 20:00 UTC)

## Relation to PR #35
PR #35 (delayed market data default) can still be merged independently as a safety net for unconfigured symbols. With **both** PR #34 + this PR + reverting strategy.live.yaml to live data (mktDataType=1), QQQ should get true real-time live ticks via the user's existing subscription.

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_