### PR TITLE
config(live): set data.market_data_type=1 for real-time bars (requires API subscription)

### DIFF
--- a/config/strategy.live.yaml
+++ b/config/strategy.live.yaml
@@ -14,6 +14,14 @@ data:
   feed: ibkr_live
   bar_interval_seconds: 60        # ignored when signal.name=sma_vwap_cross_tick
   options_feed: ibkr_live
+  # 1 = live real-time data (requires an API-eligible IBKR market-data
+  #     subscription; without one, IBKR returns Error 420 and zero bars
+  #     flow because reqRealTimeBars is live-only).
+  # 3 = delayed 15-min data (free; works on any IBKR account but no good
+  #     for a near-RT strategy on minute bars).
+  # We've subscribed to API real-time data for QQQ, so use 1 here. Flip
+  # back to 3 temporarily if a subscription lapses or while testing.
+  market_data_type: 1
 
 broker:
   name: ibkr


### PR DESCRIPTION
## Summary
Sets `data.market_data_type: 1` (real-time live) in `config/strategy.live.yaml`. This is the production-mode setting — but **you must complete the IBKR subscription step first**:

1. **Message IBKR support** via the Client Portal to confirm exactly which subscription unlocks API real-time access for QQQ. Sample message:

> I currently subscribe to "US Equity and Options Add-On Streaming Bundle (NP)" and "US Real-Time Non Consolidated Streaming Quotes (IBKR-PRO)". When I request real-time market data for QQQ via the TWS API, I get Error 420: requires additional subscription for API. Delayed data works. Which additional subscription do I need to enable real-time market data for QQQ specifically over the API (not just TWS)?

2. **Subscribe to whatever they recommend** (best guess: `NASDAQ TotalView-OpenView (NP, L2)` at $16.50/mo).

3. **Wait for activation** (5–60 min).

4. **Then merge this PR and redeploy** market-data-stream + strategy-engine. Bars will start flowing.

## Behaviour with subscription
- ✅ `mktDataType=1` honored by IBKR
- ✅ `reqRealTimeBars` returns 5-second live bars on the NASDAQ tape
- ✅ Bars persisted on /status flips to ●Healthy with live arrival rate

## Behaviour without subscription (or if it lapses)
- ❌ IBKR returns `Error 420` and no bars flow (the state we've been in all day)
- 🔧 Quick fix: flip `market_data_type: 3` in this YAML and redeploy — back to free delayed bars

## Test plan
- [x] `uv run python -c "from config.schema import load_config; ..."` parses cleanly, fields surface correctly
- [ ] After subscription activates + merge: `railway up --detach --service market-data-stream && sleep 90 && railway logs --service market-data-stream | grep -iE 'error 420|mktDataType|bar' | tail -10` → expect `mktDataType=1` and NO `Error 420`
- [ ] /status: Bars persisted ●Healthy, Live feed arrival rate climbs above 0/min

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_