### PR TITLE
fix(web): filter bars queries to interval_seconds=60 so charts render after backfill

### DIFF
--- a/apps/web/src/app/charts/ChartView.tsx
+++ b/apps/web/src/app/charts/ChartView.tsx
@@ -84,6 +84,7 @@ export default function ChartView({
           .from("bars")
           .select("symbol,open_time,open,high,low,close,volume,vwap")
           .eq("symbol", symbol)
+          .eq("interval_seconds", 60)
           .gte("open_time", startIso)
           .lte("open_time", endIso)
           .order("open_time", { ascending: true }),

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -86,10 +86,15 @@ export async function fetchChartBars(
   if (!supabase) return [];
   const dayStart = `${day}T00:00:00Z`;
   const dayEnd = `${day}T23:59:59Z`;
+  // bars table holds multiple intervals (1m / 5m / 1h / 1d) -- both the
+  // live market-data-stream and the backfill script write rows. The chart
+  // is a 1-minute intraday view, so filter to interval_seconds=60 or the
+  // result is an interleaved mess of timeframes.
   const { data, error } = await supabase
     .from("bars")
     .select("symbol,open_time,open,high,low,close,volume,vwap")
     .eq("symbol", symbol)
+    .eq("interval_seconds", 60)
     .gte("open_time", dayStart)
     .lte("open_time", dayEnd)
     .order("open_time", { ascending: true });
@@ -801,9 +806,12 @@ export interface RecentBar {
 export async function fetchRecentBars(limit = 10): Promise<RecentBar[]> {
   const supabase = getSupabase();
   if (!supabase) return [];
+  // Filter to 1-minute bars so /status's "Live feed" doesn't get a mix
+  // of 1m / 5m / 1h / 1d rows after the backfill script runs.
   const { data, error } = await supabase
     .from("bars")
     .select("symbol,open_time,close,volume")
+    .eq("interval_seconds", 60)
     .order("open_time", { ascending: false })
     .limit(limit);
   if (error || !data) return [];


### PR DESCRIPTION
## Summary
When the live market-data-stream was the only writer to the `bars` table, every row was a 60-second bar — so no interval filter was needed on chart queries. But the yfinance backfill script (`scripts/backfill_bars.py`) writes **1m / 5m / 1h / 1d** bars to the SAME table for the same symbol/day, so since we ran the backfill the chart has been returning an interleaved mess that the chart component can't render (duplicate `open_time`s in the same minute spanning different intervals collapse to whichever row Supabase returns first).

That's why the user reports "data is in supabase but still not plotting on the chart" — there ARE rows, but they're a mix of timeframes.

## Fix
Add `.eq("interval_seconds", 60)` to:
- `lib/queries.ts:fetchChartBars` (server-rendered /charts initial load)
- `lib/queries.ts:fetchRecentBars` (/status "Live feed" panel)
- `app/charts/ChartView.tsx` (client-side range refetch when the date selector changes)

`fetchAvailableSymbols` stays unfiltered — it's just collecting distinct symbol values and the interval doesn't matter there.

## Test plan
- [ ] After merge: refresh /charts in the dashboard — 1-minute bars should plot for today (yfinance ~15-min lagged)
- [ ] /status: "Live feed" panel shows recent 1-minute bars, not a confusing mix
- [ ] Range mode in ChartView still works — selecting a multi-day range should pull all 1-min bars within it
- [ ] Backtest unaffected (different code path)

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_