### PR TITLE
fix(backtest): reset strategy session state at day boundaries so multi-day backtests actually find crosses

### DIFF
--- a/engine/strategies/buy_vol_qqq_cross.py
+++ b/engine/strategies/buy_vol_qqq_cross.py
@@ -137,6 +137,20 @@ class BuyVolQQQCrossStrategy:
         self._prev_diff: Decimal | None = None
         self._open_legs: dict[tuple[str, str, str, str], _OpenLeg] = {}
 
+    def reset_session(self) -> None:
+        """Drop intraday state at the start of a new trading session.
+
+        Session VWAP and the SMA/VWAP cross detector depend on intraday
+        bars only -- when replaying multi-day data (Supabase-bars backtest
+        or the live engine across midnight) the caller must invoke this
+        on each session boundary, otherwise prior-day bars contaminate
+        VWAP and crosses stop firing. Open positions in _open_legs are
+        intentionally preserved; the caller decides whether to flatten
+        them across sessions.
+        """
+        self._bars.clear()
+        self._prev_diff = None
+
     # ------------------------------------------------------------------ helpers
 
     @staticmethod

--- a/scripts/backtest.py
+++ b/scripts/backtest.py
@@ -17,7 +17,7 @@ import logging
 import os
 import uuid
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import date, datetime
 from decimal import Decimal
 from pathlib import Path
 
@@ -184,6 +184,12 @@ async def run_backtest(
     bar_history: list[Bar] = []
     open_records: dict[uuid.UUID, TradeRecord] = {}
     report = Report()
+    # Track the date of the previous bar so we can reset the strategy's
+    # intraday state at session boundaries. Without this, multi-day
+    # backtests carry prior-day bars into VWAP/SMA buffers and crosses
+    # almost never fire after the first day. (See engine.strategies.
+    # buy_vol_qqq_cross.BuyVolQQQCrossStrategy.reset_session for why.)
+    prev_session_date: date | None = None
 
     # When pulling from Supabase, use the caller-supplied interval; for
     # fixtures the value is fixed by the JSON schema.
@@ -193,6 +199,10 @@ async def run_backtest(
     async for bar in feed.stream_equity_bars(
         cfg.universe.symbol, stream_interval
     ):
+        if prev_session_date is not None and bar.open_time.date() != prev_session_date:
+            strategy.reset_session()
+        prev_session_date = bar.open_time.date()
+
         bar_history.append(bar)
 
         chain = await options_feed.get_option_chain(


### PR DESCRIPTION
## Summary
When the backtest replays multi-day Supabase bars, the strategy appends every bar to `self._bars` and computes session VWAP across the entire buffer. Day 2's bars get mixed with Day 1's into a multi-day VWAP that almost never crosses SMA(9) again — that's why `/backtest` was showing exactly **1 trade across 7 days** of QQQ 1-min bars (the cross on the first day) and silence afterward.

## Fix
1. Add `BuyVolQQQCrossStrategy.reset_session()` which clears the intraday bar buffer and the `prev_diff` cross-detector state. Open option legs are intentionally preserved — the caller (live engine vs backtest) decides whether to flatten across sessions.
2. Track `prev_session_date` in the backtest loop and call `strategy.reset_session()` whenever `bar.open_time.date()` changes. Fixture backtests (single-day data) are unaffected.

## Why this matters
After this lands, a 7-day backtest should produce ~5–30 trades (0–5 SMA9/VWAP crosses per day × 7 sessions) instead of 1. The strategy can finally be evaluated honestly.

## Test plan
- [x] `uv run pytest tests/test_strategies tests/test_backtest_split.py -q` → 25 passed
- [x] Local fixture run still works (single-day, unchanged)
- [ ] After merge: run /backtest with QQQ Supabase bars over a 7-day range → expect summary to show multiple closed trades
- [ ] The "open_at_fixture_end" trade we kept seeing should still appear at the very end of the range (no future data to close it), but it'll be one of N, not the only one

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_