### PR TITLE
fix(backtest): SyntheticOptionsFeed honors wrapped feed's bar interval (5m/1h/1d no longer 500)

### DIFF
--- a/engine/data_feeds/supabase_bars.py
+++ b/engine/data_feeds/supabase_bars.py
@@ -58,6 +58,14 @@ class SupabaseBarsFeed(BaseFeed):
         self._pool: Any | None = None
         self._cached_bars: list[Bar] | None = None
 
+    @property
+    def interval_seconds(self) -> int:
+        """Bar resolution this feed is loaded for. Exposed so wrappers like
+        SyntheticOptionsFeed can match the interval when streaming bars
+        (the feed enforces a strict interval match in stream_equity_bars).
+        """
+        return self._interval
+
     async def _ensure_pool(self) -> Any:
         if self._pool is None:
             import asyncpg

--- a/engine/data_feeds/synthetic_options.py
+++ b/engine/data_feeds/synthetic_options.py
@@ -119,8 +119,16 @@ class SyntheticOptionsFeed(BaseFeed):
         sym = symbol.upper()
         if sym in self._last_close:
             return self._last_close[sym]
+        # Match whatever resolution the wrapped feed is loaded for.
+        # SupabaseBarsFeed enforces a strict interval match in
+        # stream_equity_bars (raises ValueError on mismatch), so the
+        # previous hardcoded 60 here 500'd the backtest API any time a
+        # user picked 5m / 1h / 1d in the dashboard. Other feeds
+        # (yfinance, replay, IBKR delayed) default to 60s, so the
+        # fallback preserves their behaviour.
+        interval = getattr(self._equity, "interval_seconds", 60)
         last: Decimal | None = None
-        async for bar in self._equity.stream_equity_bars(sym, 60):
+        async for bar in self._equity.stream_equity_bars(sym, interval):
             last = bar.close
         if last is None:
             raise RuntimeError(


### PR DESCRIPTION
## Summary
The /backtest UI returned `sidecar 500: Internal Server Error` whenever the user picked **5m / 1h / 1d** for a Supabase-bars run. Traceback from the backtest-api logs:

```
File "/app/engine/data_feeds/synthetic_options.py", line 123, in _latest_close
  async for bar in self._equity.stream_equity_bars(sym, 60):
File "/app/engine/data_feeds/supabase_bars.py", line 110, in stream_equity_bars
  raise ValueError(
ValueError: feed loaded for 3600s bars, asked for 60s
```

`SyntheticOptionsFeed._latest_close` was hardcoded to `stream_equity_bars(sym, 60)` — a holdover from when 1-minute bars were the only resolution in the system. `SupabaseBarsFeed` strictly validates the interval matches what's loaded, so any non-60s request blew up.

## Fix
1. Add a public `interval_seconds` property on `SupabaseBarsFeed` so wrappers can introspect without reaching into `_interval`.
2. `SyntheticOptionsFeed._latest_close` now uses `getattr(self._equity, "interval_seconds", 60)` — asks the wrapped feed for its resolution, falls back to 60s for feeds that don't expose one (yfinance, ReplayFeed, IBKR variants — none of which enforce a strict match, so the fallback preserves their behaviour).

## Test plan
- [x] `uv run pytest tests/test_data_feeds tests/test_strategies tests/test_backtest_split.py -q` → 65 passed
- [ ] After merge: `railway up --detach --service backtest-api` then run /backtest with QQQ 1h or 1d — expect a report, not a 500
- [ ] /backtest with QQQ 1m still works (interval=60 was always the working case)

## Out of scope
The "1-trade-only" behaviour observed on a 1m 7-day Supabase backtest is a separate bug — the strategy's time-stop exit isn't firing on day boundaries, so the first entry permanently blocks subsequent crosses. Investigating in a follow-up PR after this one merges.

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_