### PR TITLE
feat(backfill-worker): one-shot Railway service to backfill bars + signals

### DIFF
--- a/infra/railway/backfill-worker.json
+++ b/infra/railway/backfill-worker.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://railway.app/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "services/backfill-worker/Dockerfile",
+    "watchPatterns": [
+      "contracts/**",
+      "config/**",
+      "engine/**",
+      "services/persistence/**",
+      "services/backfill-worker/**",
+      "scripts/backfill_runner.py",
+      "scripts/backfill_bars_ibkr.py",
+      "scripts/backfill_signals.py",
+      "pyproject.toml",
+      "uv.lock"
+    ]
+  },
+  "deploy": {
+    "startCommand": "python -m scripts.backfill_runner",
+    "restartPolicyType": "NEVER"
+  }
+}

--- a/scripts/backfill_runner.py
+++ b/scripts/backfill_runner.py
@@ -1,0 +1,183 @@
+"""One-shot driver that chains the IBKR bars backfill and the SMA/VWAP
+signal backfill, configured entirely via env vars. This is the entrypoint
+the ``backfill-worker`` Railway service runs — deploy the service and the
+container pulls bars + computes crosses + exits.
+
+Environment
+-----------
+
+``BACKFILL_SYMBOL``     — ticker (default ``QQQ``).
+``BACKFILL_INTERVALS``  — space-separated bar-interval seconds
+                          (default ``"60 300 3600 86400"``).
+``BACKFILL_YEARS``      — how many years of history to attempt per
+                          interval (default ``2``).
+``BACKFILL_SMA_PERIOD`` — SMA period in bars for cross detection
+                          (default ``9``).
+``BACKFILL_SKIP_BARS``  — set to "1" to skip the IBKR pull and only
+                          recompute signals from whatever bars already
+                          exist in Supabase. Useful for iterating on the
+                          indicator without re-pulling history.
+``BACKFILL_SKIP_SIGNALS`` — set to "1" to pull bars only.
+
+``IBKR_HOST`` / ``IBKR_PORT`` / ``IBKR_CLIENT_ID_BACKFILL`` flow through
+to the bars backfill (defaults: ``ib-gateway.railway.internal`` / ``4004``
+/ ``99``). ``SUPABASE_DB_URL`` is required.
+
+Failure semantics
+-----------------
+
+If a single interval fails (e.g. IBKR pacing violation, gateway down,
+empty depth), we log and continue to the next interval rather than
+aborting the whole run. That way a partial backfill still produces
+useful indicator data on the resolutions that did succeed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from datetime import UTC, datetime, timedelta
+
+from scripts import backfill_bars_ibkr, backfill_signals
+
+LOG = logging.getLogger("alpha_kite.backfill_runner")
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    return int(raw)
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    return float(raw)
+
+
+def _env_flag(name: str) -> bool:
+    return (os.getenv(name) or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _parse_intervals(raw: str) -> list[int]:
+    parts = [p for p in raw.replace(",", " ").split() if p]
+    seconds = [int(p) for p in parts]
+    for s in seconds:
+        if s not in backfill_bars_ibkr._INTERVALS:
+            raise ValueError(
+                f"unsupported interval {s}; allowed: "
+                f"{sorted(backfill_bars_ibkr._INTERVALS)}",
+            )
+    return seconds
+
+
+async def _run_one_interval(
+    symbol: str,
+    interval_seconds: int,
+    years: float,
+    sma_period: int,
+    skip_bars: bool,
+    skip_signals: bool,
+    host: str,
+    port: int,
+    client_id: int,
+) -> None:
+    end_dt = datetime.now(tz=UTC)
+    start_dt = end_dt - timedelta(days=int(years * 365))
+
+    if not skip_bars:
+        LOG.info("─── bars @ %ds — pulling %.1f years ───", interval_seconds, years)
+        try:
+            bars_counts = await backfill_bars_ibkr.run(
+                symbol=symbol,
+                interval_seconds=interval_seconds,
+                start_dt=start_dt,
+                end_dt=end_dt,
+                host=host,
+                port=port,
+                client_id=client_id,
+                max_requests=2000,
+                pace_seconds=11.0,
+                use_rth=True,
+            )
+            LOG.info(
+                "bars @ %ds done: %d requests, %d bars",
+                interval_seconds, bars_counts["requests"], bars_counts["bars"],
+            )
+        except Exception as exc:
+            LOG.exception(
+                "bars @ %ds failed (%s); continuing to next step",
+                interval_seconds, exc,
+            )
+    else:
+        LOG.info("BACKFILL_SKIP_BARS=1 — skipping IBKR pull at %ds", interval_seconds)
+
+    if not skip_signals:
+        LOG.info("─── signals @ %ds — computing %s crosses ───",
+                 interval_seconds, f"SMA{sma_period}/VWAP")
+        try:
+            sig_counts = await backfill_signals.run(
+                symbol=symbol,
+                interval_seconds=interval_seconds,
+                start_dt=start_dt,
+                end_dt=end_dt,
+                sma_period=sma_period,
+            )
+            LOG.info(
+                "signals @ %ds done: scanned %d bars, wrote %d crosses, purged %d",
+                interval_seconds, sig_counts["bars"], sig_counts["crosses"],
+                sig_counts["deleted"],
+            )
+        except Exception as exc:
+            LOG.exception("signals @ %ds failed (%s)", interval_seconds, exc)
+    else:
+        LOG.info("BACKFILL_SKIP_SIGNALS=1 — skipping signal backfill at %ds",
+                 interval_seconds)
+
+
+async def main_async() -> None:
+    symbol = os.getenv("BACKFILL_SYMBOL", "QQQ")
+    intervals = _parse_intervals(os.getenv("BACKFILL_INTERVALS", "60 300 3600 86400"))
+    years = _env_float("BACKFILL_YEARS", 2.0)
+    sma_period = _env_int("BACKFILL_SMA_PERIOD", 9)
+    skip_bars = _env_flag("BACKFILL_SKIP_BARS")
+    skip_signals = _env_flag("BACKFILL_SKIP_SIGNALS")
+    host = os.getenv("IBKR_HOST", "ib-gateway.railway.internal")
+    port = _env_int("IBKR_PORT", 4004)
+    client_id = _env_int("IBKR_CLIENT_ID_BACKFILL", 99)
+
+    LOG.info(
+        "starting backfill: symbol=%s intervals=%s years=%.1f sma=%d "
+        "ibkr=%s:%d skip_bars=%s skip_signals=%s",
+        symbol, intervals, years, sma_period, host, port, skip_bars, skip_signals,
+    )
+
+    for s in intervals:
+        await _run_one_interval(
+            symbol=symbol,
+            interval_seconds=s,
+            years=years,
+            sma_period=sma_period,
+            skip_bars=skip_bars,
+            skip_signals=skip_signals,
+            host=host,
+            port=port,
+            client_id=client_id,
+        )
+
+    LOG.info("backfill_runner finished")
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s | %(message)s",
+    )
+    asyncio.run(main_async())
+
+
+if __name__ == "__main__":
+    main()

--- a/services/backfill-worker/Dockerfile
+++ b/services/backfill-worker/Dockerfile
@@ -1,0 +1,41 @@
+# syntax=docker/dockerfile:1.6
+# Backfill worker — one-shot Railway service that pulls historical bars
+# from IBKR + computes SMA/VWAP cross signals, then exits. Mirrors the
+# strategy-engine Dockerfile so deps come from the same uv.lock.
+
+FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim AS builder
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_SYSTEM_PYTHON=1
+
+WORKDIR /app
+
+COPY --link pyproject.toml uv.lock README.md ./
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-install-project
+
+FROM python:3.11-slim AS runtime
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONPATH=/app \
+    PATH="/app/.venv/bin:$PATH"
+
+COPY --link --from=builder /app/.venv /app/.venv
+
+WORKDIR /app
+COPY --link contracts ./contracts
+COPY --link config ./config
+COPY --link engine ./engine
+COPY --link services ./services
+COPY --link scripts ./scripts
+
+# No healthcheck — this is a one-shot worker. Railway's restartPolicyType
+# is set to NEVER in the service config so a clean exit doesn't trigger a
+# redeploy loop.
+
+CMD ["python", "-m", "scripts.backfill_runner"]


### PR DESCRIPTION
## Summary

Adds a new Railway service (`backfill-worker`) that runs the IBKR bars backfill + the SMA/VWAP cross detection in a single deploy-and-exit lifecycle. Unblocks triggering a full backfill from inside Railway's VPC where `ib-gateway.railway.internal:4004` is reachable, rather than needing a local IBKR Gateway running on the dev machine.

### Files

- `scripts/backfill_runner.py` — env-driven driver. Loops `BACKFILL_INTERVALS` (default `60 300 3600 86400`), runs bars-pull then cross-detection for each. Continues past per-interval failures so partial backfills still write useful data.
- `services/backfill-worker/Dockerfile` — same `uv sync --no-dev` build as `strategy-engine`; additionally copies `scripts/` so the runner module is importable.
- `infra/railway/backfill-worker.json` — `restartPolicyType=NEVER` so the container exits cleanly when finished. No healthcheck (this is a one-shot job, not a long-running service).

### Env vars (set on the Railway service before triggering)

| Required | Var | Notes |
| --- | --- | --- |
| ✅ | `SUPABASE_DB_URL` | copy from `strategy-engine` |
| ✅ | `IBKR_HOST` | `ib-gateway.railway.internal` |
| ✅ | `IBKR_PORT` | `4004` (socat proxy in the gateway image) |
|    | `BACKFILL_SYMBOL` | default `QQQ` |
|    | `BACKFILL_INTERVALS` | default `60 300 3600 86400` (space-separated) |
|    | `BACKFILL_YEARS` | default `2` |
|    | `BACKFILL_SMA_PERIOD` | default `9` |
|    | `BACKFILL_SKIP_BARS` | `1` = recompute signals only from existing bars |
|    | `BACKFILL_SKIP_SIGNALS` | `1` = pull bars only |

### Test plan

- [ ] `railway up --service backfill-worker --detach` deploys cleanly
- [ ] Logs show `bars @ 60s — pulling 2.0 years` followed by chunk progress
- [ ] After the run, query `SELECT MIN(open_time), COUNT(*) FROM bars WHERE symbol='QQQ' AND interval_seconds=60` and confirm depth grew vs the prior 11-day window
- [ ] `signals` table shows new `scope=security` rows over the same range
- [ ] Container exits with status 0 (Railway service shows "Stopped", not crashed)

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_