### PR TITLE
fix(backfill-worker): drop --mount=type=cache (Railway builder requires id=)

### DIFF
--- a/services/backfill-worker/Dockerfile
+++ b/services/backfill-worker/Dockerfile
@@ -15,8 +15,12 @@ WORKDIR /app
 
 COPY --link pyproject.toml uv.lock README.md ./
 
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev --no-install-project
+# Railway's BuildKit fork requires `id=` on every --mount=type=cache. The
+# alternative is to thread a service-scoped cache key (like the existing
+# strategy-engine Dockerfile does); since this is a one-shot worker that
+# builds at most a handful of times we skip the cache entirely — the uv
+# install is ~10s on a cold cache, not worth the Railway-specific syntax.
+RUN uv sync --frozen --no-dev --no-install-project
 
 FROM python:3.11-slim AS runtime
 


### PR DESCRIPTION
## Summary

Backfill worker build failed on Railway with:

```
dockerfile invalid: flag '--mount=type=cache,target=/root/.cache/uv' is missing an id argument at Line 18
```

Railway's BuildKit fork requires `id=` on every cache mount. The existing `strategy-engine` Dockerfile threads a Railway-generated cache key (`id=s/7e0829de-...-/root/.cache/uv`); we drop the cache mount entirely instead since this is a one-shot worker that builds at most a handful of times — caching uv's download isn't worth the Railway-specific syntax dependency.

## Test plan

- [ ] `railway up --service backfill-worker --detach` builds without error
- [ ] Logs show the runner starting and connecting to `ib-gateway.railway.internal:4004`
- [ ] Bars start landing in Supabase tagged `feed = 'ibkr_backfill_*'`

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_