### PR TITLE
fix(backfill-runner): use start=/end= kwargs matching backfill_signals.run signature

### DIFF
--- a/scripts/backfill_runner.py
+++ b/scripts/backfill_runner.py
@@ -122,8 +122,8 @@ async def _run_one_interval(
             sig_counts = await backfill_signals.run(
                 symbol=symbol,
                 interval_seconds=interval_seconds,
-                start_dt=start_dt,
-                end_dt=end_dt,
+                start=start_dt,
+                end=end_dt,
                 sma_period=sma_period,
             )
             LOG.info(


### PR DESCRIPTION
## Summary

Runner was crashing every interval with `TypeError: run() got an unexpected keyword argument 'start_dt'` because `backfill_signals.run` takes `start=` / `end=` (not `start_dt=` / `end_dt=`). Trivial kwarg rename to match the function signature.

This was masking how many signals the runner could compute — even on intervals where the IBKR pull succeeded, the signals step blew up before writing any rows.

## Test plan

- [ ] Re-deploy `backfill-worker`
- [ ] Logs show `signals @ ...s — computing SMA9/VWAP crosses` followed by `signals @ ...s done: scanned N bars, wrote M crosses` (not the TypeError)
- [ ] Supabase `signals` table grows with `scope=security` rows for the requested window

## Separate issue (out of scope)

Logs also show `gaierror: 'ib-gateway.railway.internal' Name or service not known`. That's a Railway Private Networking toggle on the `backfill-worker` service itself — needs to be enabled in the dashboard (Settings → Networking → Private Networking). Not a code fix.

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_