### PR TITLE
fix(backfill-worker): bypass BuildKit cache + add startup probes

### DIFF
--- a/scripts/backfill_runner.py
+++ b/scripts/backfill_runner.py
@@ -149,6 +149,27 @@ async def main_async() -> None:
     port = _env_int("IBKR_PORT", 4004)
     client_id = _env_int("IBKR_CLIENT_ID_BACKFILL", 99)
 
+    # Startup probe: if you see this line in the logs you know the new image
+    # actually deployed (vs. Railway serving a cached layer with stale code).
+    LOG.info("backfill_runner build marker: signals-kwargs=start/end DNS-probe=on")
+
+    # DNS sanity check — call getaddrinfo for the configured IBKR host so we
+    # surface "Outbound IPv6 toggle off" or "Private Networking off" before
+    # we try to actually connect. Private Railway DNS returns AAAA records
+    # only; without IPv6 outbound enabled this raises gaierror.
+    try:
+        import socket
+        infos = socket.getaddrinfo(host, port, type=socket.SOCK_STREAM)
+        LOG.info(
+            "DNS probe ok: %s resolves to %s",
+            host, [a[4][0] for a in infos[:4]],
+        )
+    except Exception as exc:
+        LOG.error(
+            "DNS probe FAILED for %s:%d (%s) — check Railway Private Networking + Outbound IPv6 toggles",
+            host, port, exc,
+        )
+
     LOG.info(
         "starting backfill: symbol=%s intervals=%s years=%.1f sma=%d "
         "ibkr=%s:%d skip_bars=%s skip_signals=%s",

--- a/services/backfill-worker/Dockerfile
+++ b/services/backfill-worker/Dockerfile
@@ -29,14 +29,20 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONPATH=/app \
     PATH="/app/.venv/bin:$PATH"
 
-COPY --link --from=builder /app/.venv /app/.venv
+COPY --from=builder /app/.venv /app/.venv
 
 WORKDIR /app
-COPY --link contracts ./contracts
-COPY --link config ./config
-COPY --link engine ./engine
-COPY --link services ./services
-COPY --link scripts ./scripts
+# Drop --link on app-source COPYs: Railway's BuildKit fork has been serving
+# stale cached layers even when content changed (PR #45's fix to
+# backfill_runner.py was on origin/main but the deployed image kept the
+# pre-fix version). Plain COPY rebuilds these layers every time, which is
+# cheap (these dirs total <1 MB) and rules out a class of "why is old code
+# running" debugging.
+COPY contracts ./contracts
+COPY config ./config
+COPY engine ./engine
+COPY services ./services
+COPY scripts ./scripts
 
 # No healthcheck — this is a one-shot worker. Railway's restartPolicyType
 # is set to NEVER in the service config so a clean exit doesn't trigger a


### PR DESCRIPTION
## Summary

Two changes to unblock the backfill-worker:

### 1. Drop `--link` from app-source COPYs

Railway's BuildKit fork has been serving stale layers for `COPY --link scripts ./scripts` even when content changed. PR #45's fix to `backfill_runner.py` is on `origin/main` but the deployed container kept producing the same `TypeError: ... 'start_dt'` on every redeploy — meaning the new file never made it into the image. Plain `COPY` re-stages every build (these dirs total <1 MB, no perf impact) and rules out the cache-staleness debugging tail.

### 2. Add startup probes

So the next deploy is unambiguous:

- **Build marker log line**: `"backfill_runner build marker: signals-kwargs=start/end DNS-probe=on"` — exists only in post-fix code. If it doesn't appear in logs, Railway is still serving the old image.
- **DNS sanity probe**: `socket.getaddrinfo()` against `$IBKR_HOST` *before* trying to actually connect. Logs the resolved IPv6 addr on success, or a clear `"check Private Networking + Outbound IPv6 toggles"` message on gaierror — so we distinguish network-config issues from API-call issues without needing to read tracebacks.

## Test plan

- [ ] Deploy: `railway up --service backfill-worker --detach`
- [ ] First few log lines show `build marker: signals-kwargs=start/end DNS-probe=on` (proves new code is running)
- [ ] DNS probe line follows — either `DNS probe ok: ib-gateway.railway.internal resolves to [...]` or a clear error pointing at Railway toggles
- [ ] If DNS resolves, the actual IBKR connection succeeds and bars start landing

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_