### PR TITLE
fix(backfill-bars-ibkr): bump connectAsync timeout to 30s for proxy latency

### DIFF
--- a/scripts/backfill_bars_ibkr.py
+++ b/scripts/backfill_bars_ibkr.py
@@ -190,7 +190,11 @@ async def run(
 
     ib = IB()
     LOG.info("connecting to IBKR at %s:%s (clientId=%s)", host, port, client_id)
-    await ib.connectAsync(host, port, clientId=client_id)
+    # 30s timeout (default is 4s) — handles public-proxy round-trip latency.
+    # Each IBKR handshake step (version, startApi, managedAccounts,
+    # nextValidId) is a separate round trip; over the internet via Railway's
+    # TCP proxy that easily exceeds 4 s before apiStart fires.
+    await ib.connectAsync(host, port, clientId=client_id, timeout=30)
     LOG.info("connected; pulling %s bars for %s back to %s",
              spec.bar_size, symbol, start_dt.isoformat())
 

--- a/scripts/backfill_runner.py
+++ b/scripts/backfill_runner.py
@@ -184,7 +184,7 @@ async def main_async() -> None:
 
     # Startup probe: if you see this line in the logs you know the new image
     # actually deployed (vs. Railway serving a cached layer with stale code).
-    LOG.info("backfill_runner build marker: signals-kwargs=start/end DNS-probe=on net-probe=v2")
+    LOG.info("backfill_runner build marker: connect-timeout=30s net-probe=v2")
 
     # DNS sanity check — call getaddrinfo for the configured IBKR host so we
     # surface "Outbound IPv6 toggle off" or "Private Networking off" before


### PR DESCRIPTION
## Summary

TCP probes prove the worker successfully reaches `ibkr-gateway` via Railway's public TCP proxy in **3 milliseconds**. Then ib_insync's API handshake times out at **4 seconds** waiting for `apiStart`:

```
16:04:26,153 INFO ib_insync.client | Connected               ← TCP ok
16:04:30,154 INFO ib_insync.client | Disconnecting           ← +4s later
... await asyncio.wait_for(self.apiStart, timeout)
```

The IBKR API handshake is multiple sequential round trips (version → startApi → managedAccounts → nextValidId), each of which now traverses the public internet via Railway's load balancer instead of the in-cluster mesh. 4 s default isn't enough; bumping to 30 s.

## Test plan

- [ ] Deploy → build marker reads `connect-timeout=30s`
- [ ] Logs show `connected; pulling 1 min bars for QQQ back to 2024-...` (proves apiStart fired)
- [ ] First `chunk #1: ~390 bars, earliest=..., total=390` lands
- [ ] Subsequent chunks paginate backwards through history

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_