### PR TITLE
fix(broker): use accountSummaryAsync inside the asyncio event loop

### DIFF
--- a/engine/broker/ibkr_paper.py
+++ b/engine/broker/ibkr_paper.py
@@ -126,8 +126,19 @@ class IBKRPaperBroker(AbstractBroker):
             await result
 
         try:
-            summary = self.ib.accountSummary()
-            if asyncio.iscoroutine(summary):  # pragma: no cover - defensive
+            # ib_insync's sync ``accountSummary()`` calls ``util.run`` which
+            # tries to spin up its own event loop — that conflicts with the
+            # asyncio loop we're already in and raises
+            # "This event loop is already running". Use the async variant
+            # so we cooperate with the current loop. The fake _FakeIB used
+            # by unit tests returns a plain list from its sync method, so
+            # we accept either shape.
+            summary_call = getattr(self.ib, "accountSummaryAsync", None)
+            if summary_call is None:
+                summary = self.ib.accountSummary()
+            else:
+                summary = summary_call()
+            if asyncio.iscoroutine(summary):
                 summary = await summary
         except Exception as exc:  # pragma: no cover - depends on IB
             logger.exception("ibkr accountSummary() failed")
@@ -263,8 +274,13 @@ class IBKRPaperBroker(AbstractBroker):
                 update={"account_id": self._account_id or inner.account_id}
             )
 
-        summary = self.ib.accountSummary()
-        if asyncio.iscoroutine(summary):  # pragma: no cover - defensive
+        # See note in connect() — prefer the async variant.
+        summary_call = getattr(self.ib, "accountSummaryAsync", None)
+        if summary_call is None:
+            summary = self.ib.accountSummary()
+        else:
+            summary = summary_call()
+        if asyncio.iscoroutine(summary):
             summary = await summary
         rows = list(summary or [])
 


### PR DESCRIPTION
## Summary

**Real bug surfaced by the new Layer-2 diagnostic.** When `IBKRPaperBroker.connect()` runs inside an asyncio event loop and calls `ib.accountSummary()` (the SYNC variant), ib_insync's `util.run()` tries to spin up its own loop and raises:

```
RuntimeError: This event loop is already running
```

User's local TWS test:
```
... ib_insync.client | Connected
... ib_insync.client | Logged on to server version 176
... ib_insync.client | API connection ready
... ib_insync.ib | Synchronization complete
... engine.broker.ibkr_paper | ibkr accountSummary() failed
    File "engine/broker/ibkr_paper.py:129"
      summary = self.ib.accountSummary()
    RuntimeError: This event loop is already running
```

TWS handshake completed — gateway is fine. Our broker wrapper had the bug.

## Fix

Switch to `ib.accountSummaryAsync()` when available, fall back to the sync method otherwise. Both `connect()` (line 129) and `get_account_summary()` (line 266) had the same defect.

The unit-test fake `_FakeIB` only exposes a sync `accountSummary()`, so the `getattr(..., "accountSummaryAsync", None)` fallback keeps all 42 existing unit tests passing without touching them.

## Validation

- ✅ `ruff check engine/broker/ibkr_paper.py` clean
- ✅ `uv run pytest tests/test_broker/test_ibkr_paper_guard.py tests/test_broker/test_ibkr_paper_unit_extended.py tests/test_broker/test_dry_run.py` → 42 passed
- ⏳ User to re-run `IB_HOST=127.0.0.1 IB_PORT=4002 uv run python -m scripts.check_ibkr_connectivity` and confirm `✓ all checks passed`

## Why this matters

The fallout pattern just paid for itself. Without these tests, this bug would have hit us silently the first time `strategy_engine` tried to come up against a real TWS in production — at which point we'd have been mid-trading. Caught in 5 minutes by a 60-line diagnostic instead.

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_