### PR TITLE
fix(test): apply same NaN-safe last-price logic to e2e test

### DIFF
--- a/tests/test_broker/test_ibkr_paper_e2e.py
+++ b/tests/test_broker/test_ibkr_paper_e2e.py
@@ -213,7 +213,11 @@ async def test_order_intent_persists_to_supabase(
     Supabase, query it back, assert every field round-trips."""
     backend, writer, _ = supabase
 
-    # Pull a last-price quote so the limit is properly OTM.
+    # Pull a last-price quote so the limit is properly OTM. Without a
+    # market-data subscription (IBKR error 10089), ticker.last comes back
+    # as Decimal('NaN') — which is truthy AND parses, so the simple
+    # ``else`` fallback never fires and pydantic later rejects the NaN
+    # limit_price. Detect NaN explicitly and fall back to a sane default.
     from ib_insync import Stock  # type: ignore[import-not-found]
     contract = Stock("QQQ", "SMART", "USD")
     ticker = live_broker.ib.reqMktData(contract, "", False, False)
@@ -221,7 +225,16 @@ async def test_order_intent_persists_to_supabase(
         await asyncio.sleep(0.25)
         if ticker.last and str(ticker.last).lower() != "nan":
             break
-    last_price = Decimal(str(ticker.last)) if ticker.last else Decimal("450")
+    last_price = Decimal("450")  # safe fallback ~ QQQ neighborhood
+    if ticker.last:
+        raw = str(ticker.last)
+        if raw.lower() != "nan":
+            try:
+                parsed = Decimal(raw)
+                if parsed.is_finite():
+                    last_price = parsed
+            except Exception:
+                pass
     live_broker.ib.cancelMktData(contract)
 
     intent = _deep_otm_buy(last_price, tag=test_run_id)


### PR DESCRIPTION
## Summary

PR #51 fixed the NaN-handling in `test_ibkr_paper_integration.py`, but `test_ibkr_paper_e2e.py` has its own copy of the deep-OTM helper that wasn't updated. Layer-3 e2e run on the user's Mac hit the same bug:

```
pydantic_core._pydantic_core.ValidationError: limit_price
  Input should be a finite number, input_value=Decimal('NaN'), input_type=Decimal
```

Same fix: detect `Decimal('NaN')` explicitly via `is_finite()` and fall back to $450.

## Expected result after merge

Layer 3 should match Layer 2: `test_order_intent_persists_to_supabase` passes; the 2 RTH-dependent tests skip; `audit_log` + `daily_pnl` continue to pass.

So **3 passed + 2 skipped (market closed)** = full green for the runnable subset.

## Big-picture status

After this merges, the user's local environment will have validated:
- Layer 1 (unit): 27/27 ✅
- Layer 2 (live IBKR): 4/6 ✅, 2 skip (RTH)
- Layer 3 (live IBKR + Supabase): 3/5 ✅, 2 skip (RTH)

= **34/35 runnable tests passing** end-to-end. The 6 RTH-dependent tests will run cleanly when the market opens. That's the proof the user gated Option A on.

https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB

---
_Generated by [Claude Code](https://claude.ai/code/session_018ZQUhB63433WUgnQRna3BB)_